### PR TITLE
Refactor processing of GitLab updates

### DIFF
--- a/src/App/src/Forms/MainForm.Async.cs
+++ b/src/App/src/Forms/MainForm.Async.cs
@@ -33,7 +33,7 @@ namespace mrHelper.App.Forms
             try
             {
                await _gitClientUpdater.UpdateAsync(client,
-                  _updateManager.GetInstantProjectChecker(_workflow.State.MergeRequest.Id), updateGitStatusText);
+                  _updateManager.GetRemoteProjectChecker(_workflow.State.MergeRequestDescriptor), updateGitStatusText);
             }
             catch (Exception ex)
             {
@@ -104,7 +104,7 @@ namespace mrHelper.App.Forms
                      if (!getGitClient(mrd.HostName, mrd.ProjectName).DoesRequireClone())
                      {
                         await getGitClient(mrd.HostName, mrd.ProjectName).Updater.ManualUpdateAsync(
-                           _updateManager.GetInstantProjectChecker(_workflow.State.MergeRequest.Id), null);
+                           _updateManager.GetRemoteProjectChecker(_workflow.State.MergeRequestDescriptor), null);
                      }
                   }
                   catch (GitOperationException ex)
@@ -145,7 +145,7 @@ namespace mrHelper.App.Forms
             try
             {
                await _gitClientUpdater.UpdateAsync(client,
-                  _updateManager.GetInstantProjectChecker(_workflow.State.MergeRequest.Id), updateGitStatusText);
+                  _updateManager.GetLocalProjectChecker(_workflow.State.MergeRequest.Id), updateGitStatusText);
             }
             catch (Exception ex)
             {

--- a/src/App/src/Forms/MainForm.Async.cs
+++ b/src/App/src/Forms/MainForm.Async.cs
@@ -146,8 +146,9 @@ namespace mrHelper.App.Forms
             preGitClientInitialize();
             try
             {
-               // Using local checker because it avoid a GitLab request and quite enough here because
-               // user may select only those commits that have timestamps less than latest merge request version
+               // Using local checker because it does not make a GitLab request and it is quite enough here because
+               // user may select only those commits that already loaded and cached and have timestamps less
+               // than latest merge request version
                await _gitClientUpdater.UpdateAsync(client,
                   _updateManager.GetLocalProjectChecker(_workflow.State.MergeRequest.Id), updateGitStatusText);
             }

--- a/src/App/src/Forms/MainForm.Async.cs
+++ b/src/App/src/Forms/MainForm.Async.cs
@@ -33,7 +33,7 @@ namespace mrHelper.App.Forms
             try
             {
                await _gitClientUpdater.UpdateAsync(client,
-                  _updateManager.GetCommitChecker(_workflow.State.MergeRequest.Id), updateGitStatusText);
+                  _updateManager.GetInstantProjectChecker(_workflow.State.MergeRequest.Id), updateGitStatusText);
             }
             catch (Exception ex)
             {
@@ -104,7 +104,7 @@ namespace mrHelper.App.Forms
                      if (!getGitClient(mrd.HostName, mrd.ProjectName).DoesRequireClone())
                      {
                         await getGitClient(mrd.HostName, mrd.ProjectName).Updater.ManualUpdateAsync(
-                           _updateManager.GetCommitChecker(_workflow.State.MergeRequest.Id), null);
+                           _updateManager.GetInstantProjectChecker(_workflow.State.MergeRequest.Id), null);
                      }
                   }
                   catch (GitOperationException ex)
@@ -145,7 +145,7 @@ namespace mrHelper.App.Forms
             try
             {
                await _gitClientUpdater.UpdateAsync(client,
-                  _updateManager.GetCommitChecker(_workflow.State.MergeRequest.Id), updateGitStatusText);
+                  _updateManager.GetInstantProjectChecker(_workflow.State.MergeRequest.Id), updateGitStatusText);
             }
             catch (Exception ex)
             {

--- a/src/App/src/Forms/MainForm.Async.cs
+++ b/src/App/src/Forms/MainForm.Async.cs
@@ -33,7 +33,7 @@ namespace mrHelper.App.Forms
             try
             {
                await _gitClientUpdater.UpdateAsync(client,
-                  _updateManager.GetCommitChecker(_workflow.State.MergeRequestDescriptor), updateGitStatusText);
+                  _updateManager.GetCommitChecker(_workflow.State.MergeRequest.Id), updateGitStatusText);
             }
             catch (Exception ex)
             {
@@ -104,7 +104,7 @@ namespace mrHelper.App.Forms
                      if (!getGitClient(mrd.HostName, mrd.ProjectName).DoesRequireClone())
                      {
                         await getGitClient(mrd.HostName, mrd.ProjectName).Updater.ManualUpdateAsync(
-                           _updateManager.GetCommitChecker(_workflow.State.MergeRequestDescriptor), null);
+                           _updateManager.GetCommitChecker(_workflow.State.MergeRequest.Id), null);
                      }
                   }
                   catch (GitOperationException ex)
@@ -145,7 +145,7 @@ namespace mrHelper.App.Forms
             try
             {
                await _gitClientUpdater.UpdateAsync(client,
-                  _updateManager.GetCommitChecker(_workflow.State.MergeRequestDescriptor), updateGitStatusText);
+                  _updateManager.GetCommitChecker(_workflow.State.MergeRequest.Id), updateGitStatusText);
             }
             catch (Exception ex)
             {

--- a/src/App/src/Forms/MainForm.Async.cs
+++ b/src/App/src/Forms/MainForm.Async.cs
@@ -32,6 +32,7 @@ namespace mrHelper.App.Forms
             preGitClientInitialize();
             try
             {
+               // Using remote checker because there are might be discussions reported by other users on newer commits
                await _gitClientUpdater.UpdateAsync(client,
                   _updateManager.GetRemoteProjectChecker(_workflow.State.MergeRequestDescriptor), updateGitStatusText);
             }
@@ -103,6 +104,7 @@ namespace mrHelper.App.Forms
                   {
                      if (!getGitClient(mrd.HostName, mrd.ProjectName).DoesRequireClone())
                      {
+                        // Using remote checker because there are might be discussions reported by other users on newer commits
                         await getGitClient(mrd.HostName, mrd.ProjectName).Updater.ManualUpdateAsync(
                            _updateManager.GetRemoteProjectChecker(_workflow.State.MergeRequestDescriptor), null);
                      }
@@ -144,6 +146,8 @@ namespace mrHelper.App.Forms
             preGitClientInitialize();
             try
             {
+               // Using local checker because it avoid a GitLab request and quite enough here because
+               // user may select only those commits that have timestamps less than latest merge request version
                await _gitClientUpdater.UpdateAsync(client,
                   _updateManager.GetLocalProjectChecker(_workflow.State.MergeRequest.Id), updateGitStatusText);
             }

--- a/src/App/src/Forms/MainForm.Designer.cs
+++ b/src/App/src/Forms/MainForm.Designer.cs
@@ -21,6 +21,7 @@ namespace mrHelper.App.Forms
          }
          _gitClientFactory?.Dispose();
          _timeTrackingTimer?.Dispose();
+         _workflow?.Dispose();
          base.Dispose(disposing);
       }
 

--- a/src/App/src/Forms/MainForm.Init.cs
+++ b/src/App/src/Forms/MainForm.Init.cs
@@ -181,7 +181,6 @@ namespace mrHelper.App.Forms
          _timeTrackingTimer.Tick += new System.EventHandler(onTimer);
 
          _workflowFactory = new WorkflowFactory(_settings);
-         _updateManager = new UpdateManager(_settings);
          _discussionManager = new DiscussionManager(_settings);
          _gitClientUpdater = new GitClientInteractiveUpdater();
          _gitClientUpdater.InitializationStatusChange +=

--- a/src/App/src/Forms/MainForm.Init.cs
+++ b/src/App/src/Forms/MainForm.Init.cs
@@ -194,6 +194,9 @@ namespace mrHelper.App.Forms
 
          createWorkflow();
 
+         subscribeToUpdates();
+         createTimeTrackingManager();
+
          try
          {
             await initializeWorkflow();
@@ -203,11 +206,7 @@ namespace mrHelper.App.Forms
             MessageBox.Show("Cannot initialize the workflow. Application cannot start. See logs for details",
                "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
             Close();
-            return;
          }
-
-         subscribeToUpdates();
-         createTimeTrackingManager();
       }
 
       private void subscribeToUpdates()
@@ -231,6 +230,8 @@ namespace mrHelper.App.Forms
                // emulate project change to reload merge request list
                // This will automatically update commit list (if there are new ones).
                // This will also remove closed merge requests from the list.
+               Trace.TraceInformation("[MainForm] Emulating project change to reload merge request list");
+
                try
                {
                   await _workflow.SwitchProjectAsync(_workflow.State.Project.Path_With_Namespace);

--- a/src/App/src/Forms/MainForm.Utils.cs
+++ b/src/App/src/Forms/MainForm.Utils.cs
@@ -347,12 +347,14 @@ namespace mrHelper.App.Forms
 
       private void notifyOnMergeRequestUpdates(MergeRequestUpdates updates)
       {
-         foreach (MergeRequest mergeRequest in updates.NewMergeRequests)
+         List<MergeRequest> newMergeRequests = Tools.FilterMergeRequests(updates.NewMergeRequests, _settings);
+         foreach (MergeRequest mergeRequest in newMergeRequests)
          {
             notifyOnMergeRequestEvent(mergeRequest, "New merge request");
          }
 
-         foreach (MergeRequest mergeRequest in updates.UpdatedMergeRequests)
+         List<MergeRequest> updatedMergeRequests = Tools.FilterMergeRequests(updates.UpdatedMergeRequests, _settings);
+         foreach (MergeRequest mergeRequest in updatedMergeRequests)
          {
             notifyOnMergeRequestEvent(mergeRequest, "New commit in merge request");
          }

--- a/src/App/src/Forms/MainForm.Utils.cs
+++ b/src/App/src/Forms/MainForm.Utils.cs
@@ -366,7 +366,7 @@ namespace mrHelper.App.Forms
 
             try
             {
-               _gitClientFactory = new GitClientFactory(localFolder, _workflowUpdateChecker);
+               _gitClientFactory = new GitClientFactory(localFolder, _updateManager.GetProjectWatcher());
             }
             catch (ArgumentException ex)
             {

--- a/src/App/src/Forms/MainForm.Workflow.cs
+++ b/src/App/src/Forms/MainForm.Workflow.cs
@@ -14,6 +14,7 @@ using mrHelper.Common.Interfaces;
 using mrHelper.Core;
 using mrHelper.Client;
 using mrHelper.Client.Tools;
+using mrHelper.Client.Updates;
 using mrHelper.Client.Workflow;
 using mrHelper.Client.TimeTracking;
 
@@ -40,7 +41,8 @@ namespace mrHelper.App.Forms
          _workflow.PostLoadCommits += (state, commits) => onCommitsLoaded(state, commits);
          _workflow.FailedLoadCommits += () => onFailedLoadCommits();
 
-         _workflowUpdateChecker = _updateManager.GetWorkflowUpdateChecker(_workflow, this);
+         _updateManager = new UpdateManager(_workflow, this, _settings);
+         _workflowUpdateChecker = _updateManager.GetWorkflowUpdateChecker();
          _workflowUpdateChecker.OnUpdate += async (updates) =>
          {
             notifyOnMergeRequestUpdates(updates);

--- a/src/App/src/Forms/MainForm.Workflow.cs
+++ b/src/App/src/Forms/MainForm.Workflow.cs
@@ -187,6 +187,8 @@ namespace mrHelper.App.Forms
 
       private void onProjectChanged(WorkflowState state, List<MergeRequest> mergeRequests)
       {
+         mergeRequests = Tools.FilterMergeRequests(mergeRequests, _settings);
+
          Debug.Assert(comboBoxFilteredMergeRequests.Items.Count == 0);
          foreach (var mergeRequest in mergeRequests)
          {

--- a/src/App/src/Forms/MainForm.Workflow.cs
+++ b/src/App/src/Forms/MainForm.Workflow.cs
@@ -52,6 +52,7 @@ namespace mrHelper.App.Forms
                return;
             }
 
+            // check if currently selected project is affected by update
             if (updates.NewMergeRequests.Any(x => x.Project_Id == state.Project.Id)
              || updates.UpdatedMergeRequests.Any(x => x.Project_Id == state.Project.Id)
              || updates.ClosedMergeRequests.Any(x => x.Project_Id == state.Project.Id))

--- a/src/App/src/Forms/MainForm.Workflow.cs
+++ b/src/App/src/Forms/MainForm.Workflow.cs
@@ -22,16 +22,6 @@ namespace mrHelper.App.Forms
 {
    internal partial class MainForm
    {
-      async private Task initializeWorkflow()
-      {
-         createWorkflow();
-
-         string hostname = getInitialHostName();
-         Trace.TraceInformation(String.Format("[MainForm.Workflow] Initializing workflow for host {0}", hostname));
-
-         await _workflow.Initialize(hostname);
-      }
-
       private void createWorkflow()
       {
          _workflow = _workflowFactory.CreateWorkflow();
@@ -50,6 +40,14 @@ namespace mrHelper.App.Forms
          _workflow.PreLoadCommits += () => onLoadCommits();
          _workflow.PostLoadCommits += (state, commits) => onCommitsLoaded(state, commits);
          _workflow.FailedLoadCommits += () => onFailedLoadCommits();
+      }
+
+      async private Task initializeWorkflow()
+      {
+         string hostname = getInitialHostName();
+         Trace.TraceInformation(String.Format("[MainForm.Workflow] Initializing workflow for host {0}", hostname));
+
+         await _workflow.Initialize(hostname);
       }
 
       async private Task changeHostAsync(string hostName)

--- a/src/App/src/Forms/MainForm.cs
+++ b/src/App/src/Forms/MainForm.cs
@@ -79,7 +79,6 @@ namespace mrHelper.App.Forms
       private GitClientInteractiveUpdater _gitClientUpdater;
 
       private Workflow _workflow;
-      private WorkflowUpdateChecker _workflowUpdateChecker;
       private TimeTracker _timeTracker;
 
       private ColorScheme _colorScheme = new ColorScheme();

--- a/src/App/src/Helpers/GitClientInteractiveUpdater.cs
+++ b/src/App/src/Helpers/GitClientInteractiveUpdater.cs
@@ -28,7 +28,7 @@ namespace mrHelper.App.Helpers
       /// Throw GitOperationException on unrecoverable errors.
       /// Throw CancelledByUserException and RepeatOperationException.
       /// </summary>
-      async internal Task UpdateAsync(GitClient client, CommitChecker commitChecker, Action<string> onProgressChange)
+      async internal Task UpdateAsync(GitClient client, InstantProjectChecker instantChecker, Action<string> onProgressChange)
       {
          if (client.DoesRequireClone() && !isCloneAllowed(client.Path))
          {
@@ -38,7 +38,7 @@ namespace mrHelper.App.Helpers
 
          InitializationStatusChange?.Invoke("Updating git repository...");
 
-         await runAsync(async () => await client.Updater.ManualUpdateAsync(commitChecker, onProgressChange));
+         await runAsync(async () => await client.Updater.ManualUpdateAsync(instantChecker, onProgressChange));
          InitializationStatusChange?.Invoke("Git repository updated");
       }
 

--- a/src/App/src/Helpers/GitClientInteractiveUpdater.cs
+++ b/src/App/src/Helpers/GitClientInteractiveUpdater.cs
@@ -28,7 +28,8 @@ namespace mrHelper.App.Helpers
       /// Throw GitOperationException on unrecoverable errors.
       /// Throw CancelledByUserException and RepeatOperationException.
       /// </summary>
-      async internal Task UpdateAsync(GitClient client, InstantProjectChecker instantChecker, Action<string> onProgressChange)
+      async internal Task UpdateAsync(GitClient client, IInstantProjectChecker instantChecker,
+         Action<string> onProgressChange)
       {
          if (client.DoesRequireClone() && !isCloneAllowed(client.Path))
          {

--- a/src/Client/mrHelper.Client.csproj
+++ b/src/Client/mrHelper.Client.csproj
@@ -60,7 +60,6 @@
     <Compile Include="src\Tools\MergeRequestDescriptor.cs" />
     <Compile Include="src\Tools\OperatorException.cs" />
     <Compile Include="src\Tools\Tools.cs" />
-    <Compile Include="src\Updates\InstantProjectChecker.cs" />
     <Compile Include="src\Git\GitClientUpdater.cs" />
     <Compile Include="src\Updates\ProjectWatcher.cs" />
     <Compile Include="src\Updates\ProjectWatcherItf.cs" />
@@ -69,6 +68,9 @@
     <Compile Include="src\Updates\WorkflowDetails.cs" />
     <Compile Include="src\Updates\WorkflowDetailsChecker.cs" />
     <Compile Include="src\Updates\WorkflowDetailsCache.cs" />
+    <Compile Include="src\Updates\InstantProjectCheckerItf.cs" />
+    <Compile Include="src\Updates\LocalProjectChecker.cs" />
+    <Compile Include="src\Updates\RemoteProjectChecker.cs" />
     <Compile Include="src\Workflow\Workflow.cs" />
     <Compile Include="src\Workflow\WorkflowDataOperator.cs" />
     <Compile Include="src\Workflow\WorkflowFactory.cs" />

--- a/src/Client/mrHelper.Client.csproj
+++ b/src/Client/mrHelper.Client.csproj
@@ -66,8 +66,9 @@
     <Compile Include="src\Updates\UpdateManager.cs" />
     <Compile Include="src\Updates\UpdateOperator.cs" />
     <Compile Include="src\Updates\WorkflowDetails.cs" />
-    <Compile Include="src\Updates\WorkflowDetailsChecker.cs" />
+    <Compile Include="src\Updates\WorkflowDetailsItf.cs" />
     <Compile Include="src\Updates\WorkflowDetailsCache.cs" />
+    <Compile Include="src\Updates\WorkflowDetailsChecker.cs" />
     <Compile Include="src\Updates\InstantProjectCheckerItf.cs" />
     <Compile Include="src\Updates\LocalProjectChecker.cs" />
     <Compile Include="src\Updates\RemoteProjectChecker.cs" />

--- a/src/Client/mrHelper.Client.csproj
+++ b/src/Client/mrHelper.Client.csproj
@@ -62,11 +62,13 @@
     <Compile Include="src\Tools\Tools.cs" />
     <Compile Include="src\Updates\CommitChecker.cs" />
     <Compile Include="src\Git\GitClientUpdater.cs" />
+    <Compile Include="src\Updates\ProjectWatcher.cs" />
     <Compile Include="src\Updates\ProjectWatcherItf.cs" />
     <Compile Include="src\Updates\UpdateManager.cs" />
     <Compile Include="src\Updates\UpdateOperator.cs" />
-    <Compile Include="src\Updates\WorkflowUpdateChecker.cs" />
-    <Compile Include="src\Updates\WorkflowDetailsCacheItf.cs" />
+    <Compile Include="src\Updates\WorkflowDetails.cs" />
+    <Compile Include="src\Updates\WorkflowDetailsChecker.cs" />
+    <Compile Include="src\Updates\WorkflowDetailsCache.cs" />
     <Compile Include="src\Workflow\Workflow.cs" />
     <Compile Include="src\Workflow\WorkflowDataOperator.cs" />
     <Compile Include="src\Workflow\WorkflowFactory.cs" />

--- a/src/Client/mrHelper.Client.csproj
+++ b/src/Client/mrHelper.Client.csproj
@@ -66,6 +66,7 @@
     <Compile Include="src\Updates\UpdateManager.cs" />
     <Compile Include="src\Updates\UpdateOperator.cs" />
     <Compile Include="src\Updates\WorkflowUpdateChecker.cs" />
+    <Compile Include="src\Updates\WorkflowDetailsCacheItf.cs" />
     <Compile Include="src\Workflow\Workflow.cs" />
     <Compile Include="src\Workflow\WorkflowDataOperator.cs" />
     <Compile Include="src\Workflow\WorkflowFactory.cs" />

--- a/src/Client/mrHelper.Client.csproj
+++ b/src/Client/mrHelper.Client.csproj
@@ -60,7 +60,7 @@
     <Compile Include="src\Tools\MergeRequestDescriptor.cs" />
     <Compile Include="src\Tools\OperatorException.cs" />
     <Compile Include="src\Tools\Tools.cs" />
-    <Compile Include="src\Updates\CommitChecker.cs" />
+    <Compile Include="src\Updates\InstantProjectChecker.cs" />
     <Compile Include="src\Git\GitClientUpdater.cs" />
     <Compile Include="src\Updates\ProjectWatcher.cs" />
     <Compile Include="src\Updates\ProjectWatcherItf.cs" />

--- a/src/Client/src/Git/GitClientUpdater.cs
+++ b/src/Client/src/Git/GitClientUpdater.cs
@@ -38,7 +38,7 @@ namespace mrHelper.Client.Git
       async public Task ManualUpdateAsync(IInstantProjectChecker instantChecker, Action<string> onProgressChange)
       {
          Trace.TraceInformation(
-            String.Format("[GitClientUpdater] Processing manual update. Stored LatestChange: {0}. IInstantProjectChecker: {1}",
+            String.Format("[GitClientUpdater] Processing manual update. Stored LatestChange: {0}. ProjectChecker: {1}",
                _latestChange.ToLocalTime().ToString(), (instantChecker?.ToString() ?? "null")));
 
          if (instantChecker == null)
@@ -56,7 +56,7 @@ namespace mrHelper.Client.Git
                newLatestChange.ToLocalTime().ToString()));
 
             // this may cancel currently running onTimer update
-            await checkTimestampAndUpdate(newLatestChange, onProgressChange, true);
+            await checkTimestampAndUpdate(newLatestChange, onProgressChange);
          }
          finally
          {
@@ -105,7 +105,7 @@ namespace mrHelper.Client.Git
          _updating = true;
          try
          {
-            await checkTimestampAndUpdate(updateTimestamp, null, false);
+            await checkTimestampAndUpdate(updateTimestamp, null);
          }
          catch (GitOperationException ex)
          {
@@ -118,8 +118,7 @@ namespace mrHelper.Client.Git
          }
       }
 
-      async private Task checkTimestampAndUpdate(DateTime newLatestChange, Action<string> onProgressChange,
-         bool errorIfNewIsOlder)
+      async private Task checkTimestampAndUpdate(DateTime newLatestChange, Action<string> onProgressChange)
       {
          if (newLatestChange > _latestChange)
          {
@@ -137,15 +136,7 @@ namespace mrHelper.Client.Git
          }
          else if (newLatestChange < _latestChange)
          {
-            if (errorIfNewIsOlder)
-            {
-               Debug.Assert(false);
-               Trace.TraceWarning("[GitClientUpdater] New LatestChange is older than a previous one");
-            }
-            else
-            {
-               Trace.TraceInformation("[GitClientUpdater] New LatestChange is older than a previous one");
-            }
+            Trace.TraceInformation("[GitClientUpdater] New LatestChange is older than a previous one");
          }
       }
 

--- a/src/Client/src/Git/GitClientUpdater.cs
+++ b/src/Client/src/Git/GitClientUpdater.cs
@@ -35,10 +35,10 @@ namespace mrHelper.Client.Git
          }
       }
 
-      async public Task ManualUpdateAsync(InstantProjectChecker instantChecker, Action<string> onProgressChange)
+      async public Task ManualUpdateAsync(IInstantProjectChecker instantChecker, Action<string> onProgressChange)
       {
          Trace.TraceInformation(
-            String.Format("[GitClientUpdater] Processing manual update. Stored LatestChange: {0}. InstantProjectChecker: {1}",
+            String.Format("[GitClientUpdater] Processing manual update. Stored LatestChange: {0}. IInstantProjectChecker: {1}",
                _latestChange.ToLocalTime().ToString(), (instantChecker?.ToString() ?? "null")));
 
          if (instantChecker == null)

--- a/src/Client/src/Git/GitClientUpdater.cs
+++ b/src/Client/src/Git/GitClientUpdater.cs
@@ -35,13 +35,13 @@ namespace mrHelper.Client.Git
          }
       }
 
-      async public Task ManualUpdateAsync(CommitChecker commitChecker, Action<string> onProgressChange)
+      async public Task ManualUpdateAsync(InstantProjectChecker instantChecker, Action<string> onProgressChange)
       {
          Trace.TraceInformation(
-            String.Format("[GitClientUpdater] Processing manual update. LatestChange: {0}. CommitChecker: {1}",
-               _latestChange.ToLocalTime().ToString(), (commitChecker?.ToString() ?? "null")));
+            String.Format("[GitClientUpdater] Processing manual update. LatestChange: {0}. InstantProjectChecker: {1}",
+               _latestChange.ToLocalTime().ToString(), (instantChecker?.ToString() ?? "null")));
 
-         if (commitChecker == null)
+         if (instantChecker == null)
          {
             Debug.WriteLine(String.Format("[GitClientUpdater] Unexpected case, manual update w/o commit checker"));
             Debug.Assert(false);
@@ -52,7 +52,7 @@ namespace mrHelper.Client.Git
          DateTime latestChange = _latestChange;
          try
          {
-            DateTime createdAt = commitChecker.GetLatestCommitTimestamp();
+            DateTime createdAt = instantChecker.GetLatestChangeTimestamp();
             Trace.TraceInformation(
                String.Format("[GitClientUpdater] Latest Commit details: Created_At: {0}",
                   createdAt.ToLocalTime().ToString()));

--- a/src/Client/src/Git/GitClientUpdater.cs
+++ b/src/Client/src/Git/GitClientUpdater.cs
@@ -52,15 +52,15 @@ namespace mrHelper.Client.Git
          DateTime latestChange = _latestChange;
          try
          {
-            Commit commit = await commitChecker.GetLatestCommitAsync();
+            DateTime createdAt = commitChecker.GetLatestCommitTimestamp();
             Trace.TraceInformation(
-               String.Format("[GitClientUpdater] Latest Commit details: SHA {0}, Created_At: {1}",
-                  commit.Id, commit.Created_At.ToLocalTime().ToString()));
-            if (commit.Created_At > latestChange)
+               String.Format("[GitClientUpdater] Latest Commit details: Created_At: {0}",
+                  createdAt.ToLocalTime().ToString()));
+            if (createdAt > latestChange)
             {
                Trace.TraceInformation(String.Format("[GitClientUpdater] Manual update detected commits newer than {0}",
                   latestChange.ToLocalTime().ToString()));
-               latestChange = commit.Created_At;
+               latestChange = createdAt;
 
                await doUpdate(onProgressChange); // this may cancel currently running onTimer update
 

--- a/src/Client/src/Tools/Tools.cs
+++ b/src/Client/src/Tools/Tools.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Configuration;
@@ -62,14 +63,31 @@ namespace mrHelper.Client.Tools
          return String.Empty;
       }
 
-      public static List<string> SplitLabels(string labels)
+      public static List<MergeRequest> FilterMergeRequests(List<MergeRequest> mergeRequests,
+         UserDefinedSettings settings)
       {
-         var result = new List<string>();
-         foreach (var item in labels.Split(','))
+         Func<MergeRequest, bool> DoesMatchLabels =
+            (x) =>
          {
-            result.Add(item.Trim(' '));
-         }
-         return result;
+            Func<string, List<string>> SplitLabels =
+               (labels) =>
+            {
+               List<string> result = new List<string>();
+               foreach (var item in labels.Split(','))
+               {
+                  result.Add(item.Trim(' '));
+               }
+               return result;
+            };
+
+            if (!settings.CheckedLabelsFilter)
+            {
+               return true;
+            }
+            return SplitLabels(settings.LastUsedLabels).Intersect(x.Labels).Count() != 0;
+         };
+
+         return mergeRequests.Where((x) => DoesMatchLabels(x)).ToList();
       }
 
       private class HostInProjectsFile

--- a/src/Client/src/Updates/CommitChecker.cs
+++ b/src/Client/src/Updates/CommitChecker.cs
@@ -17,37 +17,28 @@ namespace mrHelper.Client.Updates
       /// <summary>
       /// Binds to the specific MergeRequestDescriptor
       /// </summary>
-      internal CommitChecker(MergeRequestDescriptor mrd, UpdateOperator updateOperator)
+      internal CommitChecker(int mergeRequestId, WorkflowUpdateChecker updateChecker)
       {
-         MergeRequestDescriptor = mrd;
-         UpdateOperator = updateOperator;
+         MergeRequestId = mergeRequestId;
+         UpdateChecker = updateChecker;
       }
 
       /// <summary>
       /// Check for commits newer than the given timestamp
       /// Throws nothing
       /// </summary>
-      async public Task<Commit> GetLatestCommitAsync()
+      public DateTime GetLatestCommitTimestamp()
       {
-         try
-         {
-            return await UpdateOperator.GetLatestCommitAsync(MergeRequestDescriptor);
-         }
-         catch (OperatorException ex)
-         {
-            ExceptionHandlers.Handle(ex, "Cannot check for commits");
-         }
-         return new Commit();
+         return UpdateChecker.GetLatestCommitTimestamp(MergeRequestId);
       }
 
       public override string ToString()
       {
-         return String.Format("MRD: HostName={0}, ProjectName={1}, IId={2}",
-            MergeRequestDescriptor.HostName, MergeRequestDescriptor.ProjectName, MergeRequestDescriptor.IId);
+         return String.Format("MergeRequest Id: {0}", MergeRequestId);
       }
 
-      private MergeRequestDescriptor MergeRequestDescriptor { get; }
-      private UpdateOperator UpdateOperator { get; }
+      private int MergeRequestId { get; }
+      private WorkflowUpdateChecker UpdateChecker { get; }
    }
 }
 

--- a/src/Client/src/Updates/CommitChecker.cs
+++ b/src/Client/src/Updates/CommitChecker.cs
@@ -17,10 +17,10 @@ namespace mrHelper.Client.Updates
       /// <summary>
       /// Binds to the specific MergeRequestDescriptor
       /// </summary>
-      internal CommitChecker(int mergeRequestId, WorkflowUpdateChecker updateChecker)
+      internal CommitChecker(int mergeRequestId, IWorkflowDetailsCache detailsCache)
       {
          MergeRequestId = mergeRequestId;
-         UpdateChecker = updateChecker;
+         DetailsCache = detailsCache;
       }
 
       /// <summary>
@@ -29,7 +29,7 @@ namespace mrHelper.Client.Updates
       /// </summary>
       public DateTime GetLatestCommitTimestamp()
       {
-         return UpdateChecker.GetLatestCommitTimestamp(MergeRequestId);
+         return DetailsCache.GetLatestCommitTimestamp(MergeRequestId);
       }
 
       public override string ToString()
@@ -38,7 +38,7 @@ namespace mrHelper.Client.Updates
       }
 
       private int MergeRequestId { get; }
-      private WorkflowUpdateChecker UpdateChecker { get; }
+      private IWorkflowDetailsCache DetailsCache { get; }
    }
 }
 

--- a/src/Client/src/Updates/CommitChecker.cs
+++ b/src/Client/src/Updates/CommitChecker.cs
@@ -38,7 +38,7 @@ namespace mrHelper.Client.Updates
       }
 
       private int MergeRequestId { get; }
-      private IWorkflowDetailsCache DetailsCache { get; }
+      private WorkflowDetails Details { get; }
    }
 }
 

--- a/src/Client/src/Updates/CommitChecker.cs
+++ b/src/Client/src/Updates/CommitChecker.cs
@@ -17,10 +17,10 @@ namespace mrHelper.Client.Updates
       /// <summary>
       /// Binds to the specific MergeRequestDescriptor
       /// </summary>
-      internal CommitChecker(int mergeRequestId, IWorkflowDetailsCache detailsCache)
+      internal CommitChecker(int mergeRequestId, WorkflowDetails details)
       {
          MergeRequestId = mergeRequestId;
-         DetailsCache = detailsCache;
+         Details = details;
       }
 
       /// <summary>
@@ -29,7 +29,7 @@ namespace mrHelper.Client.Updates
       /// </summary>
       public DateTime GetLatestCommitTimestamp()
       {
-         return DetailsCache.GetLatestCommitTimestamp(MergeRequestId);
+         return Details.Commits[MergeRequestId];
       }
 
       public override string ToString()

--- a/src/Client/src/Updates/CommitChecker.cs
+++ b/src/Client/src/Updates/CommitChecker.cs
@@ -29,7 +29,7 @@ namespace mrHelper.Client.Updates
       /// </summary>
       public DateTime GetLatestCommitTimestamp()
       {
-         return Details.Commits[MergeRequestId];
+         return Details.GetLatestCommitTimestamp(MergeRequestId);
       }
 
       public override string ToString()

--- a/src/Client/src/Updates/InstantProjectChecker.cs
+++ b/src/Client/src/Updates/InstantProjectChecker.cs
@@ -10,26 +10,26 @@ using mrHelper.Client.Git;
 namespace mrHelper.Client.Updates
 {
    /// <summary>
-   /// Checks for new commits
+   /// Checks for changes in GitLab projects
    /// </summary>
-   public class CommitChecker
+   public class InstantProjectChecker
    {
       /// <summary>
       /// Binds to the specific MergeRequestDescriptor
       /// </summary>
-      internal CommitChecker(int mergeRequestId, WorkflowDetails details)
+      internal InstantProjectChecker(int mergeRequestId, WorkflowDetails details)
       {
          MergeRequestId = mergeRequestId;
          Details = details;
       }
 
       /// <summary>
-      /// Check for commits newer than the given timestamp
+      /// Get a timestamp of the most recent change of a project the merge request belongs to
       /// Throws nothing
       /// </summary>
-      public DateTime GetLatestCommitTimestamp()
+      public DateTime GetLatestChangeTimestamp()
       {
-         return Details.GetLatestCommitTimestamp(MergeRequestId);
+         return Details.GetLatestChangeTimestamp(MergeRequestId);
       }
 
       public override string ToString()

--- a/src/Client/src/Updates/InstantProjectCheckerItf.cs
+++ b/src/Client/src/Updates/InstantProjectCheckerItf.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using GitLabSharp.Entities;
+using mrHelper.Client.Tools;
+using mrHelper.Client.Git;
+
+namespace mrHelper.Client.Updates
+{
+   public interface IInstantProjectChecker
+   {
+      DateTime GetLatestChangeTimestamp();
+   }
+}
+

--- a/src/Client/src/Updates/LocalProjectChecker.cs
+++ b/src/Client/src/Updates/LocalProjectChecker.cs
@@ -51,7 +51,7 @@ namespace mrHelper.Client.Updates
 
       public override string ToString()
       {
-         return String.Format("MergeRequest Id: {0}", MergeRequestId);
+         return String.Format("LocalProjectChecker. MergeRequest Id: {0}", MergeRequestId);
       }
 
       private int MergeRequestId { get; }

--- a/src/Client/src/Updates/LocalProjectChecker.cs
+++ b/src/Client/src/Updates/LocalProjectChecker.cs
@@ -12,24 +12,36 @@ namespace mrHelper.Client.Updates
    /// <summary>
    /// Checks for changes in GitLab projects
    /// </summary>
-   public class InstantProjectChecker
+   public class LocalProjectChecker : IInstantProjectChecker
    {
       /// <summary>
       /// Binds to the specific MergeRequestDescriptor
       /// </summary>
-      internal InstantProjectChecker(int mergeRequestId, WorkflowDetails details)
+      internal LocalProjectChecker(int mergeRequestId, WorkflowDetails details)
       {
          MergeRequestId = mergeRequestId;
          Details = details;
       }
 
       /// <summary>
-      /// Get a timestamp of the most recent change of a project the merge request belongs to
+      /// 
       /// Throws nothing
       /// </summary>
       public DateTime GetLatestChangeTimestamp()
       {
-         return Details.GetLatestChangeTimestamp(MergeRequestId);
+         int projectId = Details.GetProjectId(MergeRequestId);
+         Debug.Assert(projectId != 0);
+
+         DateTime dateTime = DateTime.MinValue;
+
+         List<MergeRequest> mergeRequests = Details.GetMergeRequests(projectId);
+         foreach (MergeRequest mergeRequest in mergeRequests)
+         {
+            DateTime latestChange = Details.GetLatestChangeTimestamp(mergeRequest.Id);
+            dateTime = latestChange > dateTime ? latestChange : dateTime;
+         }
+
+         return dateTime;
       }
 
       public override string ToString()

--- a/src/Client/src/Updates/LocalProjectChecker.cs
+++ b/src/Client/src/Updates/LocalProjectChecker.cs
@@ -14,7 +14,7 @@ namespace mrHelper.Client.Updates
    /// </summary>
    public class LocalProjectChecker : IInstantProjectChecker
    {
-      internal LocalProjectChecker(int mergeRequestId, WorkflowDetails details)
+      internal LocalProjectChecker(int mergeRequestId, IWorkflowDetails details)
       {
          MergeRequestId = mergeRequestId;
          Details = details;
@@ -55,7 +55,7 @@ namespace mrHelper.Client.Updates
       }
 
       private int MergeRequestId { get; }
-      private WorkflowDetails Details { get; }
+      private IWorkflowDetails Details { get; }
    }
 }
 

--- a/src/Client/src/Updates/LocalProjectChecker.cs
+++ b/src/Client/src/Updates/LocalProjectChecker.cs
@@ -10,13 +10,10 @@ using mrHelper.Client.Git;
 namespace mrHelper.Client.Updates
 {
    /// <summary>
-   /// Checks for changes in GitLab projects
+   /// Detects the latest change in a merge request using Local cache only
    /// </summary>
    public class LocalProjectChecker : IInstantProjectChecker
    {
-      /// <summary>
-      /// Binds to the specific MergeRequestDescriptor
-      /// </summary>
       internal LocalProjectChecker(int mergeRequestId, WorkflowDetails details)
       {
          MergeRequestId = mergeRequestId;
@@ -24,24 +21,32 @@ namespace mrHelper.Client.Updates
       }
 
       /// <summary>
-      /// 
+      /// Get a timestamp of the most recent change of a project the merge request belongs to
       /// Throws nothing
       /// </summary>
       public DateTime GetLatestChangeTimestamp()
       {
-         int projectId = Details.GetProjectId(MergeRequestId);
-         Debug.Assert(projectId != 0);
+         /*
+            Commented out: advanced algorithm of detecting the most latest timestamp
+            It optimizes things in some cases but in case of big number of MRs it may become inefficient
+            and cause often `git fetch` calls. May be it will be optimized and uncommented later.
 
-         DateTime dateTime = DateTime.MinValue;
+            int projectId = Details.GetProjectId(MergeRequestId);
+            Debug.Assert(projectId != 0);
 
-         List<MergeRequest> mergeRequests = Details.GetMergeRequests(projectId);
-         foreach (MergeRequest mergeRequest in mergeRequests)
-         {
-            DateTime latestChange = Details.GetLatestChangeTimestamp(mergeRequest.Id);
-            dateTime = latestChange > dateTime ? latestChange : dateTime;
-         }
+            DateTime dateTime = DateTime.MinValue;
 
-         return dateTime;
+            List<MergeRequest> mergeRequests = Details.GetMergeRequests(projectId);
+            foreach (MergeRequest mergeRequest in mergeRequests)
+            {
+               DateTime latestChange = Details.GetLatestChangeTimestamp(mergeRequest.Id);
+               dateTime = latestChange > dateTime ? latestChange : dateTime;
+            }
+
+            return dateTime;
+         */
+
+         return Details.GetLatestChangeTimestamp(MergeRequestId);
       }
 
       public override string ToString()

--- a/src/Client/src/Updates/ProjectWatcher.cs
+++ b/src/Client/src/Updates/ProjectWatcher.cs
@@ -46,7 +46,8 @@ namespace mrHelper.Client.Updates
          DateTime updateTimestamp = DateTime.MinValue;
          foreach (MergeRequest mergeRequest in mergeRequests)
          {
-            string projectName = details.GetProjectName(mergeRequest.Project_Id);
+            ProjectKey key = new ProjectKey{ HostName = hostname, ProjectId = mergeRequest.Project_Id };
+            string projectName = details.GetProjectName(key);
 
             // Excluding duplicates
             for (int iUpdate = projectUpdates.Count - 1; iUpdate >= 0; --iUpdate)

--- a/src/Client/src/Updates/ProjectWatcher.cs
+++ b/src/Client/src/Updates/ProjectWatcher.cs
@@ -1,8 +1,7 @@
 using System;
-using System.ComponentModel;
-using mrHelper.Client.Git;
-using mrHelper.Client.Tools;
-using mrHelper.Client.Workflow;
+using System.Collections.Generic;
+using System.Diagnostics;
+using GitLabSharp.Entities;
 
 namespace mrHelper.Client.Updates
 {
@@ -11,17 +10,12 @@ namespace mrHelper.Client.Updates
    /// </summary>
    internal class ProjectWatcher : IProjectWatcher
    {
-      internal ProjectWatcher(UserDefinedSettings settings)
-      {
-         Settings = settings;
-      }
-
       public event Action<List<ProjectUpdate>> OnProjectUpdate;
 
       /// <summary>
       /// Convert passed updates to ProjectUpdates and notify subscribers
       /// </summary>
-      internal void ProcessUpdates(string MergeRequestUpdates updates, string hostname, WorkflowDetails details)
+      internal void ProcessUpdates(MergeRequestUpdates updates, string hostname, WorkflowDetails details)
       {
          List<ProjectUpdate> projectUpdates = new List<ProjectUpdate>();
          projectUpdates.AddRange(getProjectUpdates(updates.NewMergeRequests, hostname, details));
@@ -52,7 +46,7 @@ namespace mrHelper.Client.Updates
          DateTime latestChange = DateTime.MinValue;
          foreach (MergeRequest mergeRequest in mergeRequests)
          {
-            string projectName = details.GetProjectName(mergeRequest.Project.Id);
+            string projectName = details.GetProjectName(mergeRequest.Project_Id);
 
             // Excluding duplicates
             for (int iUpdate = projectUpdates.Count - 1; iUpdate >= 0; --iUpdate)
@@ -63,8 +57,8 @@ namespace mrHelper.Client.Updates
                }
             }
 
-            latestChange = details.GetLatestCommitAsync(mergeRequest.Id) > latestChange ?
-               details.GetLatestCommitAsync(mergeRequest.Id) : latestChange;
+            latestChange = details.GetLatestCommitTimestamp(mergeRequest.Id) > latestChange ?
+               details.GetLatestCommitTimestamp(mergeRequest.Id) : latestChange;
 
             projectUpdates.Add(
                new ProjectUpdate
@@ -77,8 +71,6 @@ namespace mrHelper.Client.Updates
 
          return projectUpdates;
       }
-
-      private UserDefinedSettings Settings { get; }
    }
 }
 

--- a/src/Client/src/Updates/ProjectWatcher.cs
+++ b/src/Client/src/Updates/ProjectWatcher.cs
@@ -21,15 +21,14 @@ namespace mrHelper.Client.Updates
          projectUpdates.AddRange(getProjectUpdates(updates.NewMergeRequests, hostname, details));
          projectUpdates.AddRange(getProjectUpdates(updates.UpdatedMergeRequests, hostname, details));
 
-         Debug.WriteLine(String.Format("[ProjectWatcher] Updating {0} projects", projectUpdates.Count));
          if (projectUpdates.Count > 0)
          {
             foreach (ProjectUpdate projectUpdate in projectUpdates)
             {
-               Trace.TraceInformation(String.Format(
-                  "[ProjectWatcher] Updating project: Host {0}, Name {1}, TimeStamp {2}",
-                  projectUpdate.HostName, projectUpdate.ProjectName,
-                  projectUpdate.LatestChange.ToLocalTime().ToString()));
+               Trace.TraceInformation(
+                  String.Format("[ProjectWatcher] Updating project: Host {0}, Name {1}, TimeStamp {2}",
+                     projectUpdate.HostName, projectUpdate.ProjectName,
+                     projectUpdate.LatestChange.ToLocalTime().ToString()));
             }
             OnProjectUpdate?.Invoke(projectUpdates);
          }

--- a/src/Client/src/Updates/ProjectWatcher.cs
+++ b/src/Client/src/Updates/ProjectWatcher.cs
@@ -1,0 +1,77 @@
+using System;
+using System.ComponentModel;
+using mrHelper.Client.Git;
+using mrHelper.Client.Tools;
+using mrHelper.Client.Workflow;
+
+namespace mrHelper.Client.Updates
+{
+   internal class ProjectWatcher : IProjectWatcher
+   {
+      internal ProjectWatcher(UserDefinedSettings settings)
+      {
+         Settings = settings;
+      }
+
+      public event Action<List<ProjectUpdate>> OnProjectUpdate;
+
+      internal void ProcessUpdates(MergeRequestUpdates updates)
+      {
+         List<ProjectUpdate> projectUpdates = new List<ProjectUpdate>();
+         projectUpdates.AddRange(getProjectUpdates(state.HostName, updates.NewMergeRequests));
+         projectUpdates.AddRange(getProjectUpdates(state.HostName, updates.UpdatedMergeRequests));
+
+         Debug.WriteLine(String.Format("[ProjectWatcher] Updating {0} projects", projectUpdates.Count));
+         if (projectUpdates.Count > 0)
+         {
+            foreach (ProjectUpdate projectUpdate in projectUpdates)
+            {
+               Trace.TraceInformation(String.Format(
+                  "[ProjectWatcher] Updating project: Host {0}, Name {1}, TimeStamp {2}",
+                  projectUpdate.HostName, projectUpdate.ProjectName,
+                  projectUpdate.LatestChange.ToLocalTime().ToString()));
+            }
+            OnProjectUpdate?.Invoke(projectUpdates);
+         }
+      }
+
+      /// <summary>
+      /// Convert a list of Project Id to list of Project names
+      /// </summary>
+      private List<ProjectUpdate> getProjectUpdates(string hostname, List<MergeRequest> mergeRequests)
+      {
+         List<ProjectUpdate> projectUpdates = new List<ProjectUpdate>();
+
+         DateTime latestChange = DateTime.MinValue;
+         foreach (MergeRequest mergeRequest in mergeRequests)
+         {
+            string projectName = getMergeRequestProjectName(mergeRequest);
+            for (int iUpdate = projectUpdates.Count - 1; iUpdate >= 0; --iUpdate)
+            {
+               if (projectUpdates[iUpdate].ProjectName == projectName)
+               {
+                  projectUpdates.RemoveAt(iUpdate);
+               }
+            }
+
+            latestChange = _cachedCommits[mergeRequest.Id] > latestChange ?
+               _cachedCommits[mergeRequest.Id] : latestChange;
+
+            projectUpdates.Add(
+               new ProjectUpdate
+               {
+                  HostName = hostname,
+                  ProjectName = getMergeRequestProjectName(mergeRequest),
+                  LatestChange = latestChange
+               });
+         }
+
+         return projectUpdates;
+      }
+
+      private UserDefinedSettings Settings { get; }
+   }
+}
+
+
+

--- a/src/Client/src/Updates/ProjectWatcher.cs
+++ b/src/Client/src/Updates/ProjectWatcher.cs
@@ -28,7 +28,7 @@ namespace mrHelper.Client.Updates
                Trace.TraceInformation(
                   String.Format("[ProjectWatcher] Updating project: Host {0}, Name {1}, TimeStamp {2}",
                      projectUpdate.HostName, projectUpdate.ProjectName,
-                     projectUpdate.LatestChange.ToLocalTime().ToString()));
+                     projectUpdate.Timestamp.ToLocalTime().ToString()));
             }
             OnProjectUpdate?.Invoke(projectUpdates);
          }
@@ -42,7 +42,8 @@ namespace mrHelper.Client.Updates
       {
          List<ProjectUpdate> projectUpdates = new List<ProjectUpdate>();
 
-         DateTime latestChange = DateTime.MinValue;
+         // Check all the updated merge request to figure out the latest change among them
+         DateTime updateTimestamp = DateTime.MinValue;
          foreach (MergeRequest mergeRequest in mergeRequests)
          {
             string projectName = details.GetProjectName(mergeRequest.Project_Id);
@@ -56,15 +57,15 @@ namespace mrHelper.Client.Updates
                }
             }
 
-            latestChange = details.GetLatestChangeTimestamp(mergeRequest.Id) > latestChange ?
-               details.GetLatestChangeTimestamp(mergeRequest.Id) : latestChange;
+            updateTimestamp = details.GetLatestChangeTimestamp(mergeRequest.Id) > updateTimestamp ?
+               details.GetLatestChangeTimestamp(mergeRequest.Id) : updateTimestamp;
 
             projectUpdates.Add(
                new ProjectUpdate
                {
                   HostName = hostname,
                   ProjectName = projectName,
-                  LatestChange = latestChange
+                  Timestamp = updateTimestamp
                });
          }
 

--- a/src/Client/src/Updates/ProjectWatcher.cs
+++ b/src/Client/src/Updates/ProjectWatcher.cs
@@ -15,7 +15,7 @@ namespace mrHelper.Client.Updates
       /// <summary>
       /// Convert passed updates to ProjectUpdates and notify subscribers
       /// </summary>
-      internal void ProcessUpdates(MergeRequestUpdates updates, string hostname, WorkflowDetails details)
+      internal void ProcessUpdates(MergeRequestUpdates updates, string hostname, IWorkflowDetails details)
       {
          List<ProjectUpdate> projectUpdates = new List<ProjectUpdate>();
          projectUpdates.AddRange(getProjectUpdates(updates.NewMergeRequests, hostname, details));
@@ -38,7 +38,7 @@ namespace mrHelper.Client.Updates
       /// Convert a list of Project Id to list of Project names
       /// </summary>
       private List<ProjectUpdate> getProjectUpdates(List<MergeRequest> mergeRequests, string hostname,
-         WorkflowDetails details)
+         IWorkflowDetails details)
       {
          List<ProjectUpdate> projectUpdates = new List<ProjectUpdate>();
 

--- a/src/Client/src/Updates/ProjectWatcher.cs
+++ b/src/Client/src/Updates/ProjectWatcher.cs
@@ -57,8 +57,8 @@ namespace mrHelper.Client.Updates
                }
             }
 
-            latestChange = details.GetLatestCommitTimestamp(mergeRequest.Id) > latestChange ?
-               details.GetLatestCommitTimestamp(mergeRequest.Id) : latestChange;
+            latestChange = details.GetLatestChangeTimestamp(mergeRequest.Id) > latestChange ?
+               details.GetLatestChangeTimestamp(mergeRequest.Id) : latestChange;
 
             projectUpdates.Add(
                new ProjectUpdate

--- a/src/Client/src/Updates/ProjectWatcherItf.cs
+++ b/src/Client/src/Updates/ProjectWatcherItf.cs
@@ -8,7 +8,12 @@ namespace mrHelper.Client.Updates
    {
       public string HostName;
       public string ProjectName;
-      public DateTime LatestChange;
+
+      /// <summary>
+      /// Timestamp of an event within the given project that caused this update.
+      /// If there are multiple events, Timestamp belongs to the latest of them.
+      /// </summary>
+      public DateTime Timestamp;
    }
 
    public interface IProjectWatcher

--- a/src/Client/src/Updates/RemoteProjectChecker.cs
+++ b/src/Client/src/Updates/RemoteProjectChecker.cs
@@ -6,6 +6,7 @@ using System.IO;
 using GitLabSharp.Entities;
 using mrHelper.Client.Tools;
 using mrHelper.Client.Git;
+using Version = GitLabSharp.Entities.Version;
 
 namespace mrHelper.Client.Updates
 {
@@ -28,7 +29,9 @@ namespace mrHelper.Client.Updates
       {
          try
          {
-            return Operator.GetLatestVersionAsync(MergeRequestDescriptor).Result.Created_At;
+            Task<Version> task = Task.Run<Version>(
+               async () => await Operator.GetLatestVersionAsync(MergeRequestDescriptor));
+            return task.Result.Created_At;
          }
          catch (OperatorException ex)
          {

--- a/src/Client/src/Updates/RemoteProjectChecker.cs
+++ b/src/Client/src/Updates/RemoteProjectChecker.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using GitLabSharp.Entities;
+using mrHelper.Client.Tools;
+using mrHelper.Client.Git;
+
+namespace mrHelper.Client.Updates
+{
+   /// <summary>
+   /// Checks for changes in GitLab projects
+   /// </summary>
+   public class RemoteProjectChecker : IInstantProjectChecker
+   {
+      /// <summary>
+      /// Binds to the specific MergeRequestDescriptor
+      /// </summary>
+      internal RemoteProjectChecker(MergeRequestDescriptor mrd, UpdateOperator updateOperator)
+      {
+         MergeRequestDescriptor = mrd;
+         Operator = updateOperator;
+      }
+
+      /// <summary>
+      /// Get a timestamp of the most recent change of a project the merge request belongs to
+      /// Throws nothing
+      /// </summary>
+      public DateTime GetLatestChangeTimestamp()
+      {
+         try
+         {
+            return Operator.GetLatestVersion(MergeRequestDescriptor).Created_At;
+         }
+         catch (OperatorException ex)
+         {
+            ExceptionHandlers.Handle(ex, "Cannot check for commits");
+         }
+         return DateTime.MinValue;
+      }
+
+      public override string ToString()
+      {
+         return String.Format("MRD: HostName={0}, ProjectName={1}, IId={2}",
+            MergeRequestDescriptor.HostName, MergeRequestDescriptor.ProjectName, MergeRequestDescriptor.IId);
+      }
+
+      private MergeRequestDescriptor MergeRequestDescriptor { get; }
+      private UpdateOperator Operator { get; }
+   }
+}
+

--- a/src/Client/src/Updates/RemoteProjectChecker.cs
+++ b/src/Client/src/Updates/RemoteProjectChecker.cs
@@ -42,7 +42,7 @@ namespace mrHelper.Client.Updates
 
       public override string ToString()
       {
-         return String.Format("MRD: HostName={0}, ProjectName={1}, IId={2}",
+         return String.Format("RemoteProjectChecker. MRD: HostName={0}, ProjectName={1}, IId={2}",
             MergeRequestDescriptor.HostName, MergeRequestDescriptor.ProjectName, MergeRequestDescriptor.IId);
       }
 

--- a/src/Client/src/Updates/RemoteProjectChecker.cs
+++ b/src/Client/src/Updates/RemoteProjectChecker.cs
@@ -10,13 +10,10 @@ using mrHelper.Client.Git;
 namespace mrHelper.Client.Updates
 {
    /// <summary>
-   /// Checks for changes in GitLab projects
+   /// Detects the latest change in a merge request by means of a request to GitLab
    /// </summary>
    public class RemoteProjectChecker : IInstantProjectChecker
    {
-      /// <summary>
-      /// Binds to the specific MergeRequestDescriptor
-      /// </summary>
       internal RemoteProjectChecker(MergeRequestDescriptor mrd, UpdateOperator updateOperator)
       {
          MergeRequestDescriptor = mrd;

--- a/src/Client/src/Updates/RemoteProjectChecker.cs
+++ b/src/Client/src/Updates/RemoteProjectChecker.cs
@@ -28,7 +28,7 @@ namespace mrHelper.Client.Updates
       {
          try
          {
-            return Operator.GetLatestVersion(MergeRequestDescriptor).Created_At;
+            return Operator.GetLatestVersionAsync(MergeRequestDescriptor).Result.Created_At;
          }
          catch (OperatorException ex)
          {

--- a/src/Client/src/Updates/UpdateManager.cs
+++ b/src/Client/src/Updates/UpdateManager.cs
@@ -23,9 +23,19 @@ namespace mrHelper.Client.Updates
          return WorkflowUpdateChecker;
       }
 
+      public IProjectWatcher GetProjectWatcher()
+      {
+         return WorkflowUpdateChecker;
+      }
+
       public CommitChecker GetCommitChecker(int mergeRequestId)
       {
-         return new CommitChecker(mergeRequestId, WorkflowUpdateChecker);
+         return new CommitChecker(mergeRequestId, getDetailsCache());
+      }
+
+      private IWorkflowDetailsCache getDetailsCache()
+      {
+         return WorkflowUpdateChecker;
       }
 
       private WorkflowUpdateChecker WorkflowUpdateChecker { get; }

--- a/src/Client/src/Updates/UpdateManager.cs
+++ b/src/Client/src/Updates/UpdateManager.cs
@@ -77,23 +77,22 @@ namespace mrHelper.Client.Updates
             enabledProjects, oldDetails, Cache.Details);
          ProjectWatcher.ProcessUpdates(updates, Workflow.State.HostName, Cache.Details);
 
-         Debug.WriteLine(String.Format("[UpdateManager] Found: New: {0}, Updated: {1}, Closed: {2}",
-            updates.NewMergeRequests.Count, updates.UpdatedMergeRequests.Count, updates.ClosedMergeRequests.Count));
+         int unfilteredNewMergeRequestsCount = updates.NewMergeRequests.Count;
+         int unfilteredUpdatedMergeRequestsCount = updates.UpdatedMergeRequests.Count;
+         int unfilteredClosedMergeRequestCount = updates.ClosedMergeRequests.Count;
 
-         Debug.WriteLine("[UpdateManager] Filtering New MR");
-         applyLabelFilter(updates.NewMergeRequests, Cache.Details);
-         traceUpdates(updates.NewMergeRequests, "Filtered New");
+         if (Settings.CheckedLabelsFilter)
+         {
+            applyLabelFilter(updates.NewMergeRequests, Cache.Details);
+            applyLabelFilter(updates.UpdatedMergeRequests, Cache.Details);
+            applyLabelFilter(updates.ClosedMergeRequests, Cache.Details);
+         }
 
-         Debug.WriteLine("[UpdateManager] Filtering Updated MR");
-         applyLabelFilter(updates.UpdatedMergeRequests, Cache.Details);
-         traceUpdates(updates.UpdatedMergeRequests, "Filtered Updated");
-
-         Debug.WriteLine("[UpdateManager] Filtering Closed MR");
-         applyLabelFilter(updates.ClosedMergeRequests, Cache.Details);
-         traceUpdates(updates.ClosedMergeRequests, "Filtered Closed");
-
-         Debug.WriteLine(String.Format("[UpdateManager] Filtered : New: {0}, Updated: {1}, Closed: {2}",
-            updates.NewMergeRequests.Count, updates.UpdatedMergeRequests.Count, updates.ClosedMergeRequests.Count));
+         Trace.TraceInformation(
+            String.Format("[UpdateManager] Merge Request Updates: New {0}/{1}, Updated {2}/{3}, Closed {4}/{5}",
+               updates.NewMergeRequests.Count, unfilteredNewMergeRequestsCount,
+               updates.UpdatedMergeRequests.Count, unfilteredUpdatedMergeRequestsCount,
+               updates.ClosedMergeRequests.Count, unfilteredClosedMergeRequestCount));
 
          if (updates.NewMergeRequests.Count > 0
           || updates.UpdatedMergeRequests.Count > 0
@@ -108,41 +107,13 @@ namespace mrHelper.Client.Updates
       /// </summary>
       private void applyLabelFilter(List<MergeRequest> mergeRequests, WorkflowDetails details)
       {
-         if (!Settings.CheckedLabelsFilter)
-         {
-            Debug.WriteLine("[UpdateManager] Label Filter is off");
-            return;
-         }
-
          for (int iMergeRequest = mergeRequests.Count - 1; iMergeRequest >= 0; --iMergeRequest)
          {
             MergeRequest mergeRequest = mergeRequests[iMergeRequest];
             if (_cachedLabels.Intersect(mergeRequest.Labels).Count() == 0)
             {
-               Debug.WriteLine(String.Format(
-                  "[UpdateManager] Merge request {0} from project {1} does not match labels",
-                     mergeRequest.Title, details.GetProjectName(mergeRequest.Project_Id)));
-
                mergeRequests.RemoveAt(iMergeRequest);
             }
-         }
-      }
-
-      /// <summary>
-      /// Debug trace
-      /// </summary>
-      private void traceUpdates(List<MergeRequest> mergeRequests, string name)
-      {
-         if (mergeRequests.Count == 0)
-         {
-            return;
-         }
-
-         Debug.WriteLine(String.Format("[UpdateManager] {0} Merge Requests:", name));
-
-         foreach (MergeRequest mr in mergeRequests)
-         {
-            Debug.WriteLine(String.Format("[UpdateManager] IId: {0}, Title: {1}", mr.IId, mr.Title));
          }
       }
 

--- a/src/Client/src/Updates/UpdateManager.cs
+++ b/src/Client/src/Updates/UpdateManager.cs
@@ -50,9 +50,14 @@ namespace mrHelper.Client.Updates
          return ProjectWatcher;
       }
 
-      public InstantProjectChecker GetInstantProjectChecker(int mergeRequestId)
+      public IInstantProjectChecker GetLocalProjectChecker(int mergeRequestId)
       {
-         return new InstantProjectChecker(mergeRequestId, new WorkflowDetails(Cache.Details));
+         return new LocalProjectChecker(mergeRequestId, new WorkflowDetails(Cache.Details));
+      }
+
+      public IInstantProjectChecker GetRemoteProjectChecker(MergeRequestDescriptor mrd)
+      {
+         return new RemoteProjectChecker(mrd, new UpdateOperator(Settings));
       }
 
       /// <summary>

--- a/src/Client/src/Updates/UpdateManager.cs
+++ b/src/Client/src/Updates/UpdateManager.cs
@@ -50,11 +50,17 @@ namespace mrHelper.Client.Updates
          return ProjectWatcher;
       }
 
+      /// <summary>
+      /// Checks local cache to detect if there are project changes caused by new versions of a merge request
+      /// </summary>
       public IInstantProjectChecker GetLocalProjectChecker(int mergeRequestId)
       {
          return new LocalProjectChecker(mergeRequestId, new WorkflowDetails(Cache.Details));
       }
 
+      /// <summary>
+      /// Makes a request to GitLab to detect if there are project changes caused by new versions of a merge request
+      /// </summary>
       public IInstantProjectChecker GetRemoteProjectChecker(MergeRequestDescriptor mrd)
       {
          return new RemoteProjectChecker(mrd, new UpdateOperator(Settings));

--- a/src/Client/src/Updates/UpdateManager.cs
+++ b/src/Client/src/Updates/UpdateManager.cs
@@ -50,9 +50,9 @@ namespace mrHelper.Client.Updates
          return ProjectWatcher;
       }
 
-      public CommitChecker GetCommitChecker(int mergeRequestId)
+      public InstantProjectChecker GetInstantProjectChecker(int mergeRequestId)
       {
-         return new CommitChecker(mergeRequestId, new WorkflowDetails(Cache.Details));
+         return new InstantProjectChecker(mergeRequestId, new WorkflowDetails(Cache.Details));
       }
 
       /// <summary>

--- a/src/Client/src/Updates/UpdateManager.cs
+++ b/src/Client/src/Updates/UpdateManager.cs
@@ -71,6 +71,7 @@ namespace mrHelper.Client.Updates
       /// </summary>
       async private void onTimer(object sender, System.Timers.ElapsedEventArgs e)
       {
+         string hostname = Workflow.State.HostName;
          List<Project> enabledProjects = Workflow.GetProjectsToUpdate();
          IWorkflowDetails oldDetails = Cache.Details.Clone();
 
@@ -84,7 +85,7 @@ namespace mrHelper.Client.Updates
             return;
          }
 
-         MergeRequestUpdates updates = WorkflowDetailsChecker.CheckForUpdates(
+         MergeRequestUpdates updates = WorkflowDetailsChecker.CheckForUpdates(hostname,
             enabledProjects, oldDetails, Cache.Details);
          ProjectWatcher.ProcessUpdates(updates, Workflow.State.HostName, Cache.Details);
 

--- a/src/Client/src/Updates/UpdateManager.cs
+++ b/src/Client/src/Updates/UpdateManager.cs
@@ -55,7 +55,7 @@ namespace mrHelper.Client.Updates
       /// </summary>
       public IInstantProjectChecker GetLocalProjectChecker(int mergeRequestId)
       {
-         return new LocalProjectChecker(mergeRequestId, new WorkflowDetails(Cache.Details));
+         return new LocalProjectChecker(mergeRequestId, Cache.Details.Clone());
       }
 
       /// <summary>
@@ -72,7 +72,7 @@ namespace mrHelper.Client.Updates
       async private void onTimer(object sender, System.Timers.ElapsedEventArgs e)
       {
          List<Project> enabledProjects = Workflow.GetProjectsToUpdate();
-         WorkflowDetails oldDetails = new WorkflowDetails(Cache.Details);
+         IWorkflowDetails oldDetails = Cache.Details.Clone();
 
          try
          {
@@ -116,7 +116,7 @@ namespace mrHelper.Client.Updates
       /// <summary>
       /// Remove merge requests that don't match Label Filter from the passed list
       /// </summary>
-      private void applyLabelFilter(List<MergeRequest> mergeRequests, WorkflowDetails details)
+      private void applyLabelFilter(List<MergeRequest> mergeRequests, IWorkflowDetails details)
       {
          for (int iMergeRequest = mergeRequests.Count - 1; iMergeRequest >= 0; --iMergeRequest)
          {

--- a/src/Client/src/Updates/UpdateManager.cs
+++ b/src/Client/src/Updates/UpdateManager.cs
@@ -11,11 +11,44 @@ namespace mrHelper.Client.Updates
    /// </summary>
    public class UpdateManager
    {
+      public event Action<MergeRequestUpdates> OnUpdate;
+
       public UpdateManager(Workflow.Workflow workflow, ISynchronizeInvoke synchronizeInvoke,
          UserDefinedSettings settings)
       {
          UpdateOperator updateOperator = new UpdateOperator(settings);
          WorkflowUpdateChecker = new WorkflowUpdateChecker(settings, updateOperator, workflow, synchronizeInvoke);
+         ProjectWatcher = new ProjectWatcher(settings);
+
+         Timer.Elapsed += onTimer;
+         Timer.SynchronizingObject = synchronizeInvoke;
+         Timer.Start();
+
+         workflow.PostSwitchMergeRequest += async (state) =>
+         {
+            Debug.WriteLine(String.Format(
+               "[UpdateManager] Start handling PostSwitchMergeRequest. Host: {0}, Project: {1}, IId: {2}",
+                  state.HostName, state.Project.Path_With_Namespace, state.MergeRequest.IId));
+
+            await Cache.UpdateAsync();
+
+            Debug.WriteLine(String.Format("[UpdateManager] End handling PostSwitchMergeRequest."));
+         };
+
+         Settings.PropertyChanged += (sender, property) =>
+         {
+            if (property.PropertyName == "LastUsedLabels")
+            {
+               _cachedLabels = Tools.Tools.SplitLabels(Settings.LastUsedLabels);
+               Trace.TraceInformation(String.Format("[UpdateManager] Updated cached Labels to {0}",
+                  Settings.LastUsedLabels));
+               Trace.TraceInformation("[UpdateManager] Label Filter used: " + (Settings.CheckedLabelsFilter ? "Yes" : "No"));
+            }
+         };
+
+         Trace.TraceInformation(String.Format("[UpdateManager] Initially cached Labels {0}",
+            Settings.LastUsedLabels));
+         Trace.TraceInformation("[UpdateManager] Label Filter used: " + (Settings.CheckedLabelsFilter ? "Yes" : "No"));
       }
 
       public WorkflowUpdateChecker GetWorkflowUpdateChecker()
@@ -25,20 +58,113 @@ namespace mrHelper.Client.Updates
 
       public IProjectWatcher GetProjectWatcher()
       {
-         return WorkflowUpdateChecker;
+         return ProjectWatcher;
       }
 
       public CommitChecker GetCommitChecker(int mergeRequestId)
       {
-         return new CommitChecker(mergeRequestId, getDetailsCache());
+         return new CommitChecker(mergeRequestId, Cache.Details);
       }
 
-      private IWorkflowDetailsCache getDetailsCache()
+      /// <summary>
+      /// Process a timer event
+      /// </summary>
+      async private void onTimer(object sender, System.Timers.ElapsedEventArgs e)
       {
-         return WorkflowUpdateChecker;
+         List<Project> enabledProjects = Workflow.GetEnabledProjects();
+         WorkflowDetails prevState = Cache.Details;
+
+         try
+         {
+            await Cache.UpdateAsync();
+         }
+         catch (OperatorException ex)
+         {
+            ExceptionHandlers.Handle(ex, "Auto-update failed");
+            return;
+         }
+
+         MergeRequestUpdates updates = WorkflowUpdateChecker.CheckForUpdates(enabledProjects, prevState, Cache.Details);
+         projectWatcher.ProcessUpdates(updates);
+
+         Debug.WriteLine(String.Format("[WorkflowUpdateChecker] Found: New: {0}, Updated: {1}, Closed: {2}",
+            updates.NewMergeRequests.Count, updates.UpdatedMergeRequests.Count, updates.ClosedMergeRequests.Count));
+
+         Debug.WriteLine("[ProjectWatcher] Filtering New MR");
+         applyLabelFilter(updates.NewMergeRequests);
+         traceUpdates(updates.NewMergeRequests, "Filtered New");
+
+         Debug.WriteLine("[ProjectWatcher] Filtering Updated MR");
+         applyLabelFilter(updates.UpdatedMergeRequests);
+         traceUpdates(updates.UpdatedMergeRequests, "Filtered Updated");
+
+         Debug.WriteLine("[ProjectWatcher] Filtering Closed MR");
+         applyLabelFilter(updates.ClosedMergeRequests);
+         traceUpdates(updates.ClosedMergeRequests, "Filtered Closed");
+
+         Debug.WriteLine(String.Format("[WorkflowUpdateChecker] Filtered : New: {0}, Updated: {1}, Closed: {2}",
+            updates.NewMergeRequests.Count, updates.UpdatedMergeRequests.Count, updates.ClosedMergeRequests.Count));
+
+         if (updates.NewMergeRequests.Count > 0
+          || updates.UpdatedMergeRequests.Count > 0
+          || updates.ClosedMergeRequests.Count > 0)
+         {
+            OnUpdate?.Invoke(updates);
+         }
       }
+
+      /// <summary>
+      /// Remove merge requests that don't match Label Filter from the passed list
+      /// </summary>
+      private void applyLabelFilter(List<MergeRequest> mergeRequests)
+      {
+         if (!Settings.CheckedLabelsFilter)
+         {
+            Debug.WriteLine("[UpdateManager] Label Filter is off");
+            return;
+         }
+
+         for (int iMergeRequest = mergeRequests.Count - 1; iMergeRequest >= 0; --iMergeRequest)
+         {
+            MergeRequest mergeRequest = mergeRequests[iMergeRequest];
+            if (_cachedLabels.Intersect(mergeRequest.Labels).Count() == 0)
+            {
+               Debug.WriteLine(String.Format(
+                  "[UpdateManager] Merge request {0} from project {1} does not match labels",
+                     mergeRequest.Title, getMergeRequestProjectName(mergeRequest)));
+
+               mergeRequests.RemoveAt(iMergeRequest);
+            }
+         }
+      }
+
+      /// <summary>
+      /// Debug trace
+      /// </summary>
+      private void traceUpdates(List<MergeRequest> mergeRequests, string name)
+      {
+         if (mergeRequests.Count == 0)
+         {
+            return;
+         }
+
+         Debug.WriteLine(String.Format("[WorkflowUpdateChecker] {0} Merge Requests:", name));
+
+         foreach (MergeRequest mr in mergeRequests)
+         {
+            Debug.WriteLine(String.Format("[WorkflowUpdateChecker] IId: {0}, Title: {1}", mr.IId, mr.Title));
+         }
+      }
+
+      private System.Timers.Timer Timer { get; } = new System.Timers.Timer
+         {
+            Interval = 5 * 60000 // five minutes in ms
+         };
+
+      private List<string> _cachedLabels;
 
       private WorkflowUpdateChecker WorkflowUpdateChecker { get; }
+      private ProjectWatcher ProjectWatcher { get; }
    }
 }
 

--- a/src/Client/src/Updates/UpdateManager.cs
+++ b/src/Client/src/Updates/UpdateManager.cs
@@ -29,20 +29,6 @@ namespace mrHelper.Client.Updates
          Timer.Elapsed += onTimer;
          Timer.SynchronizingObject = synchronizeInvoke;
          Timer.Start();
-         Settings.PropertyChanged += (sender, property) =>
-         {
-            if (property.PropertyName == "LastUsedLabels")
-            {
-               _cachedLabels = Tools.Tools.SplitLabels(Settings.LastUsedLabels);
-               Trace.TraceInformation(String.Format("[UpdateManager] Updated cached Labels to {0}",
-                  Settings.LastUsedLabels));
-               Trace.TraceInformation("[UpdateManager] Label Filter used: " + (Settings.CheckedLabelsFilter ? "Yes" : "No"));
-            }
-         };
-
-         Trace.TraceInformation(String.Format("[UpdateManager] Initially cached Labels {0}",
-            Settings.LastUsedLabels));
-         Trace.TraceInformation("[UpdateManager] Label Filter used: " + (Settings.CheckedLabelsFilter ? "Yes" : "No"));
       }
 
       public IProjectWatcher GetProjectWatcher()
@@ -89,52 +75,17 @@ namespace mrHelper.Client.Updates
             enabledProjects, oldDetails, Cache.Details);
          ProjectWatcher.ProcessUpdates(updates, Workflow.State.HostName, Cache.Details);
 
-         int unfilteredNewMergeRequestsCount = updates.NewMergeRequests.Count;
-         int unfilteredUpdatedMergeRequestsCount = updates.UpdatedMergeRequests.Count;
-         int unfilteredClosedMergeRequestCount = updates.ClosedMergeRequests.Count;
-
-         if (Settings.CheckedLabelsFilter)
-         {
-            applyLabelFilter(updates.NewMergeRequests, Cache.Details);
-            applyLabelFilter(updates.UpdatedMergeRequests, Cache.Details);
-            applyLabelFilter(updates.ClosedMergeRequests, Cache.Details);
-         }
-
          Trace.TraceInformation(
-            String.Format("[UpdateManager] Merge Request Updates: New {0}/{1}, Updated {2}/{3}, Closed {4}/{5}",
-               updates.NewMergeRequests.Count, unfilteredNewMergeRequestsCount,
-               updates.UpdatedMergeRequests.Count, unfilteredUpdatedMergeRequestsCount,
-               updates.ClosedMergeRequests.Count, unfilteredClosedMergeRequestCount));
+            String.Format("[UpdateManager] Merge Request Updates: New {0}, Updated {1}, Closed {2}",
+               updates.NewMergeRequests.Count, updates.UpdatedMergeRequests.Count, updates.ClosedMergeRequests.Count));
 
-         if (updates.NewMergeRequests.Count > 0
-          || updates.UpdatedMergeRequests.Count > 0
-          || updates.ClosedMergeRequests.Count > 0)
-         {
-            OnUpdate?.Invoke(updates);
-         }
-      }
-
-      /// <summary>
-      /// Remove merge requests that don't match Label Filter from the passed list
-      /// </summary>
-      private void applyLabelFilter(List<MergeRequest> mergeRequests, IWorkflowDetails details)
-      {
-         for (int iMergeRequest = mergeRequests.Count - 1; iMergeRequest >= 0; --iMergeRequest)
-         {
-            MergeRequest mergeRequest = mergeRequests[iMergeRequest];
-            if (_cachedLabels.Intersect(mergeRequest.Labels).Count() == 0)
-            {
-               mergeRequests.RemoveAt(iMergeRequest);
-            }
-         }
+         OnUpdate?.Invoke(updates);
       }
 
       private System.Timers.Timer Timer { get; } = new System.Timers.Timer
          {
             Interval = 5 * 60000 // five minutes in ms
          };
-
-      private List<string> _cachedLabels;
 
       private Workflow.Workflow Workflow { get; }
       private WorkflowDetailsCache Cache { get; }

--- a/src/Client/src/Updates/UpdateManager.cs
+++ b/src/Client/src/Updates/UpdateManager.cs
@@ -11,29 +11,24 @@ namespace mrHelper.Client.Updates
    /// </summary>
    public class UpdateManager
    {
-      public UpdateManager(UserDefinedSettings settings)
+      public UpdateManager(Workflow.Workflow workflow, ISynchronizeInvoke synchronizeInvoke,
+         UserDefinedSettings settings)
       {
-         UpdateOperator = new UpdateOperator(settings);
-         Settings = settings;
+         UpdateOperator updateOperator = new UpdateOperator(settings);
+         WorkflowUpdateChecker = new WorkflowUpdateChecker(settings, updateOperator, workflow, synchronizeInvoke);
       }
 
-      public WorkflowUpdateChecker GetWorkflowUpdateChecker(Workflow.Workflow workflow,
-         ISynchronizeInvoke synchronizeInvoke)
+      public WorkflowUpdateChecker GetWorkflowUpdateChecker()
       {
-         return new WorkflowUpdateChecker(Settings, UpdateOperator, workflow, synchronizeInvoke);
+         return WorkflowUpdateChecker;
       }
 
-      public CommitChecker GetCommitChecker(MergeRequestDescriptor mrd)
+      public CommitChecker GetCommitChecker(int mergeRequestId)
       {
-         if (mrd.IId == default(MergeRequestDescriptor).IId || mrd.HostName == String.Empty || mrd.ProjectName == String.Empty)
-         {
-            return null;
-         }
-         return new CommitChecker(mrd, UpdateOperator);
+         return new CommitChecker(mergeRequestId, WorkflowUpdateChecker);
       }
 
-      private UpdateOperator UpdateOperator { get; }
-      private UserDefinedSettings Settings { get; }
+      private WorkflowUpdateChecker WorkflowUpdateChecker { get; }
    }
 }
 

--- a/src/Client/src/Updates/UpdateOperator.cs
+++ b/src/Client/src/Updates/UpdateOperator.cs
@@ -6,6 +6,7 @@ using GitLabSharp.Accessors;
 using GitLabSharp.Entities;
 using mrHelper.Client.Tools;
 using System.Diagnostics;
+using Version = GitLabSharp.Entities.Version;
 
 namespace mrHelper.Client.Updates
 {
@@ -38,21 +39,20 @@ namespace mrHelper.Client.Updates
          }
       }
 
-      async internal Task<Commit> GetLatestCommitAsync(MergeRequestDescriptor mrd)
+      async internal Task<Version> GetLatestVersionAsync(MergeRequestDescriptor mrd)
       {
          try
          {
-            List<Commit> commits = (List<Commit>)(await Client.RunAsync(async (gitlab) =>
-               await gitlab.Projects.Get(mrd.ProjectName).MergeRequests.Get(mrd.IId).Commits.LoadTaskAsync(
-                  new PageFilter { PageNumber = 1, PerPage = 1 })));
-            return commits.Count > 0 ? commits[0] : new Commit();
+            List<Version> versions = (List<Version>)(await Client.RunAsync(async (gitlab) =>
+               await gitlab.Projects.Get(mrd.ProjectName).MergeRequests.Get(mrd.IId).Versions.LoadAllTaskAsync()));
+            return versions.Count > 0 ? versions[0] : new Version();
          }
          catch (Exception ex)
          {
             Debug.Assert(!(ex is GitLabClientCancelled));
             if (ex is GitLabSharpException || ex is GitLabRequestException)
             {
-               ExceptionHandlers.Handle(ex, "Cannot load the latest commit from GitLab");
+               ExceptionHandlers.Handle(ex, "Cannot load the latest version from GitLab");
                throw new OperatorException(ex);
             }
             throw;

--- a/src/Client/src/Updates/UpdateOperator.cs
+++ b/src/Client/src/Updates/UpdateOperator.cs
@@ -40,6 +40,33 @@ namespace mrHelper.Client.Updates
          }
       }
 
+      internal Version GetLatestVersion(MergeRequestDescriptor mrd)
+      {
+         GitLabClient client = new GitLabClient(mrd.HostName, Tools.Tools.GetAccessToken(mrd.HostName, Settings));
+         try
+         {
+            Task<object> task = client.RunAsync(
+               async (gitlab) =>
+               {
+                  VersionAccessor accessor = gitlab.Projects.Get(mrd.ProjectName).MergeRequests.Get(mrd.IId).Versions;
+                  Task<List<Version>> nestedTask = accessor.LoadAllTaskAsync();
+                  return await nestedTask;
+               });
+            List<Version> versions = (List<Version>)task.Result;
+            return versions.Count > 0 ? versions[0] : new Version();
+         }
+         catch (Exception ex)
+         {
+            Debug.Assert(!(ex is GitLabClientCancelled));
+            if (ex is GitLabSharpException || ex is GitLabRequestException)
+            {
+               ExceptionHandlers.Handle(ex, "Cannot load the latest version from GitLab");
+               throw new OperatorException(ex);
+            }
+            throw;
+         }
+      }
+
       async internal Task<Version> GetLatestVersionAsync(MergeRequestDescriptor mrd)
       {
          GitLabClient client = new GitLabClient(mrd.HostName, Tools.Tools.GetAccessToken(mrd.HostName, Settings));

--- a/src/Client/src/Updates/UpdateOperator.cs
+++ b/src/Client/src/Updates/UpdateOperator.cs
@@ -39,26 +39,6 @@ namespace mrHelper.Client.Updates
          }
       }
 
-      async internal Task<int> GetCommitsCountAsync(MergeRequestDescriptor mrd)
-      {
-         GitLabClient client = new GitLabClient(mrd.HostName, Tools.Tools.GetAccessToken(mrd.HostName, Settings));
-         try
-         {
-            return (int)(await client.RunAsync(async (gitlab) =>
-               await gitlab.Projects.Get(mrd.ProjectName).MergeRequests.Get(mrd.IId).Commits.CountTaskAsync()));
-         }
-         catch (Exception ex)
-         {
-            Debug.Assert(!(ex is GitLabClientCancelled));
-            if (ex is GitLabSharpException || ex is GitLabRequestException)
-            {
-               ExceptionHandlers.Handle(ex, "Cannot load commit count from GitLab");
-               throw new OperatorException(ex);
-            }
-            throw;
-         }
-      }
-
       async internal Task<Commit> GetLatestCommitAsync(MergeRequestDescriptor mrd)
       {
          GitLabClient client = new GitLabClient(mrd.HostName, Tools.Tools.GetAccessToken(mrd.HostName, Settings));

--- a/src/Client/src/Updates/UpdateOperator.cs
+++ b/src/Client/src/Updates/UpdateOperator.cs
@@ -15,16 +15,17 @@ namespace mrHelper.Client.Updates
    /// </summary>
    internal class UpdateOperator
    {
-      internal UpdateOperator(string host, string token)
+      internal UpdateOperator(UserDefinedSettings settings)
       {
-         Client = new GitLabClient(host, token);
+         Settings = settings;
       }
 
-      async internal Task<List<MergeRequest>> GetMergeRequestsAsync(string project)
+      async internal Task<List<MergeRequest>> GetMergeRequestsAsync(string host, string project)
       {
+         GitLabClient client = new GitLabClient(host, Tools.Tools.GetAccessToken(host, Settings));
          try
          {
-           return (List<MergeRequest>)(await Client.RunAsync(async (gitlab) =>
+           return (List<MergeRequest>)(await client.RunAsync(async (gitlab) =>
               await gitlab.Projects.Get(project).MergeRequests.LoadAllTaskAsync(new MergeRequestsFilter())));
          }
          catch (Exception ex)
@@ -41,9 +42,10 @@ namespace mrHelper.Client.Updates
 
       async internal Task<Version> GetLatestVersionAsync(MergeRequestDescriptor mrd)
       {
+         GitLabClient client = new GitLabClient(mrd.HostName, Tools.Tools.GetAccessToken(mrd.HostName, Settings));
          try
          {
-            List<Version> versions = (List<Version>)(await Client.RunAsync(async (gitlab) =>
+            List<Version> versions = (List<Version>)(await client.RunAsync(async (gitlab) =>
                await gitlab.Projects.Get(mrd.ProjectName).MergeRequests.Get(mrd.IId).Versions.LoadAllTaskAsync()));
             return versions.Count > 0 ? versions[0] : new Version();
          }
@@ -59,12 +61,7 @@ namespace mrHelper.Client.Updates
          }
       }
 
-      internal Task CancelAsync()
-      {
-         return Client.CancelAsync();
-      }
-
-      private GitLabClient Client { get; }
+      private UserDefinedSettings Settings { get; }
    }
 }
 

--- a/src/Client/src/Updates/WorkflowDetails.cs
+++ b/src/Client/src/Updates/WorkflowDetails.cs
@@ -19,7 +19,7 @@ namespace mrHelper.Client.Updates
       {
          ProjectNames = new Dictionary<int, string>(details.ProjectNames);
          MergeRequests = new Dictionary<int, List<MergeRequest>>(details.MergeRequests);
-         Commits = new Dictionary<int, DateTime>(details.Commits);
+         Changes = new Dictionary<int, DateTime>(details.Changes);
       }
 
       /// <summary>
@@ -56,20 +56,20 @@ namespace mrHelper.Client.Updates
       }
 
       /// <summary>
-      /// Return a timestamp of the most recent commit of a specified merge request
+      /// Return a timestamp of the most recent version of a specified merge request
       /// </summary>
-      internal DateTime GetLatestCommitTimestamp(int mergeRequestId)
+      internal DateTime GetLatestChangeTimestamp(int mergeRequestId)
       {
-         Debug.Assert(Commits.ContainsKey(mergeRequestId));
-         return Commits.ContainsKey(mergeRequestId) ? Commits[mergeRequestId] : DateTime.MinValue;
+         Debug.Assert(Changes.ContainsKey(mergeRequestId));
+         return Changes.ContainsKey(mergeRequestId) ? Changes[mergeRequestId] : DateTime.MinValue;
       }
 
       /// <summary>
-      /// Update a timestamp of the most recent commit of a specified merge request
+      /// Update a timestamp of the most recent version of a specified merge request
       /// </summary>
-      internal void SetLatestCommitTimestamp(int mergeRequestId, DateTime timestamp)
+      internal void SetLatestChangeTimestamp(int mergeRequestId, DateTime timestamp)
       {
-         Commits[mergeRequestId] = timestamp;
+         Changes[mergeRequestId] = timestamp;
       }
 
       // maps unique project id to project's Path with Namespace property
@@ -78,8 +78,8 @@ namespace mrHelper.Client.Updates
       // maps unique project id to list of merge requests
       private Dictionary<int, List<MergeRequest>> MergeRequests = new Dictionary<int, List<MergeRequest>>();
 
-      // maps unique Merge Request Id (not IId) to a timestamp of its latest commit
-      private Dictionary<int, DateTime> Commits = new Dictionary<int, DateTime>();
+      // maps unique Merge Request Id (not IId) to a timestamp of its latest version
+      private Dictionary<int, DateTime> Changes  = new Dictionary<int, DateTime>();
    }
 }
 

--- a/src/Client/src/Updates/WorkflowDetails.cs
+++ b/src/Client/src/Updates/WorkflowDetails.cs
@@ -11,13 +11,68 @@ using System.Diagnostics;
 
 namespace mrHelper.Client.Updates
 {
+   // TODO: It is not enough to have unique project id because of multiple hosts
+
    internal struct WorkflowDetails
    {
+      /// <summary>
+      /// Return project name (Path_With_Namespace) by unique project Id
+      /// </summary>
+      public string GetProjectName(int projectId)
+      {
+         Debug.Assert(ProjectNames.ContainsKey(projectId));
+         return ProjectNames.ContainsKey(projectId) ? ProjectNames[projectId] : String.Empty;
+      }
+
+      /// <summary>
+      /// Add a project name/id pair to the cache
+      /// </summary>
+      public void SetProjectName(int projectId, string name)
+      {
+         ProjectNames[projectId] = name;
+      }
+
+      /// <summary>
+      /// Return a list of merge requests by unique project id
+      /// </summary>
+      public List<MergeRequest> GetMergeRequests(int project Id)
+      {
+         return MergeRequests.ContainsKey(projectId) ? MergeRequests[projectId] : new List<MergeRequest>();
+      }
+
+      /// <summary>
+      /// Add a merge request to a list of merge requests for the given project
+      /// </summary>
+      public void AddMergeRequest(int projectId, MergeRequest mergeRequest)
+      {
+         GetMergeRequests(projectId).Add(mergeRequest);
+      }
+
+      /// <summary>
+      /// Return a timestamp of the most recent commit of a specified merge request
+      /// </summary>
+      public DateTime GetLatestCommitTimestamp(int mergeRequestId)
+      {
+         Debug.Assert(Commits.ContainsKey(mergeRequestId));
+         return Commits.ContainsKey(mergeRequestId) ? Commits[mergeRequestId] : DateTime.MinValue;
+      }
+
+      /// <summary>
+      /// Update a timestamp of the most recent commit of a specified merge request
+      /// </summary>
+      public void SetLatestCommitTimestamp(int mergeRequestId, DateTime timestamp)
+      {
+         Commits[mergeRequestId] = timestamp;
+      }
+
+      // maps unique project id to project's Path with Namespace property
+      private Dictionary<int, string> ProjectNames = new Dictionary<int, string>();
+
       // maps unique project id to list of merge requests
-      public Dictionary<int, List<MergeRequest>> MergeRequests;
+      private Dictionary<int, List<MergeRequest>> MergeRequests = new Dictionary<int, List<MergeRequest>>();
 
       // maps unique Merge Request Id (not IId) to a timestamp of its latest commit
-      public Dictionary<int, DateTime> Commits;
+      private Dictionary<int, DateTime> Commits = new Dictionary<int, DateTime>();
    }
 }
 

--- a/src/Client/src/Updates/WorkflowDetails.cs
+++ b/src/Client/src/Updates/WorkflowDetails.cs
@@ -63,21 +63,11 @@ namespace mrHelper.Client.Updates
       }
 
       /// <summary>
-      /// Add a merge request to a list of merge requests for the given project
+      /// Sets a list of merge requests for the given project
       /// </summary>
-      internal void AddMergeRequest(int projectId, MergeRequest mergeRequest)
+      internal void SetMergeRequests(int projectId, List<MergeRequest> mergeRequests)
       {
-         if (MergeRequests.ContainsKey(projectId))
-         {
-            if (!MergeRequests[projectId].Any((x) => x.Id == mergeRequest.Id))
-            {
-               MergeRequests[projectId].Add(mergeRequest);
-            }
-         }
-         else
-         {
-            MergeRequests[projectId] = new List<MergeRequest> { mergeRequest };
-         }
+         MergeRequests[projectId] = mergeRequests;
       }
 
       /// <summary>
@@ -94,6 +84,14 @@ namespace mrHelper.Client.Updates
       internal void SetLatestChangeTimestamp(int mergeRequestId, DateTime timestamp)
       {
          Changes[mergeRequestId] = timestamp;
+      }
+
+      /// <summary>
+      /// Remove records from Changes collection
+      /// </summary>
+      internal void CleanupTimestamps(int mergeRequestId)
+      {
+         Changes.Remove(mergeRequestId);
       }
 
       /// <summary>

--- a/src/Client/src/Updates/WorkflowDetails.cs
+++ b/src/Client/src/Updates/WorkflowDetails.cs
@@ -88,6 +88,21 @@ namespace mrHelper.Client.Updates
          Changes[mergeRequestId] = timestamp;
       }
 
+      /// <summary>
+      /// Return project Id by merge request Id
+      /// </summary>
+      internal int GetProjectId(int mergeRequestId)
+      {
+         foreach (KeyValuePair<int, List<MergeRequest>> mergeRequests in MergeRequests)
+         {
+            if (mergeRequests.Value.Any((x) => x.Id == mergeRequestId))
+            {
+               return mergeRequests.Key;
+            }
+         }
+         return 0;
+      }
+
       // maps unique project id to project's Path with Namespace property
       private Dictionary<int, string> ProjectNames;
 

--- a/src/Client/src/Updates/WorkflowDetails.cs
+++ b/src/Client/src/Updates/WorkflowDetails.cs
@@ -13,7 +13,7 @@ namespace mrHelper.Client.Updates
 {
    // TODO: It is not enough to have unique project id because of multiple hosts
 
-   internal class WorkflowDetails
+   internal class WorkflowDetails : IWorkflowDetails
    {
       internal WorkflowDetails()
       {
@@ -22,7 +22,7 @@ namespace mrHelper.Client.Updates
          Changes = new Dictionary<int, DateTime>();
       }
 
-      internal WorkflowDetails(WorkflowDetails details)
+      private WorkflowDetails(WorkflowDetails details)
       {
          ProjectNames = new Dictionary<int, string>(details.ProjectNames);
          MergeRequests = new Dictionary<int, List<MergeRequest>>(details.MergeRequests);
@@ -30,9 +30,17 @@ namespace mrHelper.Client.Updates
       }
 
       /// <summary>
+      /// Create a copy of object
+      /// </summary>
+      public IWorkflowDetails Clone()
+      {
+         return new WorkflowDetails(this);
+      }
+
+      /// <summary>
       /// Return project name (Path_With_Namespace) by unique project Id
       /// </summary>
-      internal string GetProjectName(int projectId)
+      public string GetProjectName(int projectId)
       {
          Debug.Assert(ProjectNames.ContainsKey(projectId));
          return ProjectNames.ContainsKey(projectId) ? ProjectNames[projectId] : String.Empty;
@@ -49,7 +57,7 @@ namespace mrHelper.Client.Updates
       /// <summary>
       /// Return a list of merge requests by unique project id
       /// </summary>
-      internal List<MergeRequest> GetMergeRequests(int projectId)
+      public List<MergeRequest> GetMergeRequests(int projectId)
       {
          return MergeRequests.ContainsKey(projectId) ? MergeRequests[projectId] : new List<MergeRequest>();
       }
@@ -75,7 +83,7 @@ namespace mrHelper.Client.Updates
       /// <summary>
       /// Return a timestamp of the most recent version of a specified merge request
       /// </summary>
-      internal DateTime GetLatestChangeTimestamp(int mergeRequestId)
+      public DateTime GetLatestChangeTimestamp(int mergeRequestId)
       {
          return Changes.ContainsKey(mergeRequestId) ? Changes[mergeRequestId] : DateTime.MinValue;
       }
@@ -91,7 +99,7 @@ namespace mrHelper.Client.Updates
       /// <summary>
       /// Return project Id by merge request Id
       /// </summary>
-      internal int GetProjectId(int mergeRequestId)
+      public int GetProjectId(int mergeRequestId)
       {
          foreach (KeyValuePair<int, List<MergeRequest>> mergeRequests in MergeRequests)
          {

--- a/src/Client/src/Updates/WorkflowDetails.cs
+++ b/src/Client/src/Updates/WorkflowDetails.cs
@@ -11,21 +11,19 @@ using System.Diagnostics;
 
 namespace mrHelper.Client.Updates
 {
-   // TODO: It is not enough to have unique project id because of multiple hosts
-
    internal class WorkflowDetails : IWorkflowDetails
    {
       internal WorkflowDetails()
       {
-         ProjectNames = new Dictionary<int, string>();
-         MergeRequests = new Dictionary<int, List<MergeRequest>>();
+         ProjectNames = new Dictionary<ProjectKey, string>();
+         MergeRequests = new Dictionary<ProjectKey, List<MergeRequest>>();
          Changes = new Dictionary<int, DateTime>();
       }
 
       private WorkflowDetails(WorkflowDetails details)
       {
-         ProjectNames = new Dictionary<int, string>(details.ProjectNames);
-         MergeRequests = new Dictionary<int, List<MergeRequest>>(details.MergeRequests);
+         ProjectNames = new Dictionary<ProjectKey, string>(details.ProjectNames);
+         MergeRequests = new Dictionary<ProjectKey, List<MergeRequest>>(details.MergeRequests);
          Changes = new Dictionary<int, DateTime>(details.Changes);
       }
 
@@ -40,34 +38,34 @@ namespace mrHelper.Client.Updates
       /// <summary>
       /// Return project name (Path_With_Namespace) by unique project Id
       /// </summary>
-      public string GetProjectName(int projectId)
+      public string GetProjectName(ProjectKey key)
       {
-         Debug.Assert(ProjectNames.ContainsKey(projectId));
-         return ProjectNames.ContainsKey(projectId) ? ProjectNames[projectId] : String.Empty;
+         Debug.Assert(ProjectNames.ContainsKey(key));
+         return ProjectNames.ContainsKey(key) ? ProjectNames[key] : String.Empty;
       }
 
       /// <summary>
       /// Add a project name/id pair to the cache
       /// </summary>
-      internal void SetProjectName(int projectId, string name)
+      internal void SetProjectName(ProjectKey key, string name)
       {
-         ProjectNames[projectId] = name;
+         ProjectNames[key] = name;
       }
 
       /// <summary>
       /// Return a list of merge requests by unique project id
       /// </summary>
-      public List<MergeRequest> GetMergeRequests(int projectId)
+      public List<MergeRequest> GetMergeRequests(ProjectKey key)
       {
-         return MergeRequests.ContainsKey(projectId) ? MergeRequests[projectId] : new List<MergeRequest>();
+         return MergeRequests.ContainsKey(key) ? MergeRequests[key] : new List<MergeRequest>();
       }
 
       /// <summary>
       /// Sets a list of merge requests for the given project
       /// </summary>
-      internal void SetMergeRequests(int projectId, List<MergeRequest> mergeRequests)
+      internal void SetMergeRequests(ProjectKey key, List<MergeRequest> mergeRequests)
       {
-         MergeRequests[projectId] = mergeRequests;
+         MergeRequests[key] = mergeRequests;
       }
 
       /// <summary>
@@ -97,23 +95,23 @@ namespace mrHelper.Client.Updates
       /// <summary>
       /// Return project Id by merge request Id
       /// </summary>
-      public int GetProjectId(int mergeRequestId)
+      public ProjectKey GetProjectKey(int mergeRequestId)
       {
-         foreach (KeyValuePair<int, List<MergeRequest>> mergeRequests in MergeRequests)
+         foreach (KeyValuePair<ProjectKey, List<MergeRequest>> mergeRequests in MergeRequests)
          {
             if (mergeRequests.Value.Any((x) => x.Id == mergeRequestId))
             {
                return mergeRequests.Key;
             }
          }
-         return 0;
+         return new ProjectKey { HostName = String.Empty, ProjectId = 0 };
       }
 
       // maps unique project id to project's Path with Namespace property
-      private Dictionary<int, string> ProjectNames;
+      private Dictionary<ProjectKey, string> ProjectNames;
 
       // maps unique project id to list of merge requests
-      private Dictionary<int, List<MergeRequest>> MergeRequests;
+      private Dictionary<ProjectKey, List<MergeRequest>> MergeRequests;
 
       // maps unique Merge Request Id (not IId) to a timestamp of its latest version
       private Dictionary<int, DateTime> Changes;

--- a/src/Client/src/Updates/WorkflowDetails.cs
+++ b/src/Client/src/Updates/WorkflowDetails.cs
@@ -15,6 +15,13 @@ namespace mrHelper.Client.Updates
 
    internal class WorkflowDetails
    {
+      internal WorkflowDetails()
+      {
+         ProjectNames = new Dictionary<int, string>();
+         MergeRequests = new Dictionary<int, List<MergeRequest>>();
+         Changes = new Dictionary<int, DateTime>();
+      }
+
       internal WorkflowDetails(WorkflowDetails details)
       {
          ProjectNames = new Dictionary<int, string>(details.ProjectNames);
@@ -52,7 +59,17 @@ namespace mrHelper.Client.Updates
       /// </summary>
       internal void AddMergeRequest(int projectId, MergeRequest mergeRequest)
       {
-         GetMergeRequests(projectId).Add(mergeRequest);
+         if (MergeRequests.ContainsKey(projectId))
+         {
+            if (!MergeRequests[projectId].Any((x) => x.Id == mergeRequest.Id))
+            {
+               MergeRequests[projectId].Add(mergeRequest);
+            }
+         }
+         else
+         {
+            MergeRequests[projectId] = new List<MergeRequest> { mergeRequest };
+         }
       }
 
       /// <summary>
@@ -60,7 +77,6 @@ namespace mrHelper.Client.Updates
       /// </summary>
       internal DateTime GetLatestChangeTimestamp(int mergeRequestId)
       {
-         Debug.Assert(Changes.ContainsKey(mergeRequestId));
          return Changes.ContainsKey(mergeRequestId) ? Changes[mergeRequestId] : DateTime.MinValue;
       }
 
@@ -73,13 +89,13 @@ namespace mrHelper.Client.Updates
       }
 
       // maps unique project id to project's Path with Namespace property
-      private Dictionary<int, string> ProjectNames = new Dictionary<int, string>();
+      private Dictionary<int, string> ProjectNames;
 
       // maps unique project id to list of merge requests
-      private Dictionary<int, List<MergeRequest>> MergeRequests = new Dictionary<int, List<MergeRequest>>();
+      private Dictionary<int, List<MergeRequest>> MergeRequests;
 
       // maps unique Merge Request Id (not IId) to a timestamp of its latest version
-      private Dictionary<int, DateTime> Changes  = new Dictionary<int, DateTime>();
+      private Dictionary<int, DateTime> Changes;
    }
 }
 

--- a/src/Client/src/Updates/WorkflowDetails.cs
+++ b/src/Client/src/Updates/WorkflowDetails.cs
@@ -13,12 +13,19 @@ namespace mrHelper.Client.Updates
 {
    // TODO: It is not enough to have unique project id because of multiple hosts
 
-   internal struct WorkflowDetails
+   internal class WorkflowDetails
    {
+      internal WorkflowDetails(WorkflowDetails details)
+      {
+         ProjectNames = new Dictionary<int, string>(details.ProjectNames);
+         MergeRequests = new Dictionary<int, List<MergeRequest>>(details.MergeRequests);
+         Commits = new Dictionary<int, DateTime>(details.Commits);
+      }
+
       /// <summary>
       /// Return project name (Path_With_Namespace) by unique project Id
       /// </summary>
-      public string GetProjectName(int projectId)
+      internal string GetProjectName(int projectId)
       {
          Debug.Assert(ProjectNames.ContainsKey(projectId));
          return ProjectNames.ContainsKey(projectId) ? ProjectNames[projectId] : String.Empty;
@@ -27,7 +34,7 @@ namespace mrHelper.Client.Updates
       /// <summary>
       /// Add a project name/id pair to the cache
       /// </summary>
-      public void SetProjectName(int projectId, string name)
+      internal void SetProjectName(int projectId, string name)
       {
          ProjectNames[projectId] = name;
       }
@@ -35,7 +42,7 @@ namespace mrHelper.Client.Updates
       /// <summary>
       /// Return a list of merge requests by unique project id
       /// </summary>
-      public List<MergeRequest> GetMergeRequests(int project Id)
+      internal List<MergeRequest> GetMergeRequests(int projectId)
       {
          return MergeRequests.ContainsKey(projectId) ? MergeRequests[projectId] : new List<MergeRequest>();
       }
@@ -43,7 +50,7 @@ namespace mrHelper.Client.Updates
       /// <summary>
       /// Add a merge request to a list of merge requests for the given project
       /// </summary>
-      public void AddMergeRequest(int projectId, MergeRequest mergeRequest)
+      internal void AddMergeRequest(int projectId, MergeRequest mergeRequest)
       {
          GetMergeRequests(projectId).Add(mergeRequest);
       }
@@ -51,7 +58,7 @@ namespace mrHelper.Client.Updates
       /// <summary>
       /// Return a timestamp of the most recent commit of a specified merge request
       /// </summary>
-      public DateTime GetLatestCommitTimestamp(int mergeRequestId)
+      internal DateTime GetLatestCommitTimestamp(int mergeRequestId)
       {
          Debug.Assert(Commits.ContainsKey(mergeRequestId));
          return Commits.ContainsKey(mergeRequestId) ? Commits[mergeRequestId] : DateTime.MinValue;
@@ -60,7 +67,7 @@ namespace mrHelper.Client.Updates
       /// <summary>
       /// Update a timestamp of the most recent commit of a specified merge request
       /// </summary>
-      public void SetLatestCommitTimestamp(int mergeRequestId, DateTime timestamp)
+      internal void SetLatestCommitTimestamp(int mergeRequestId, DateTime timestamp)
       {
          Commits[mergeRequestId] = timestamp;
       }

--- a/src/Client/src/Updates/WorkflowDetails.cs
+++ b/src/Client/src/Updates/WorkflowDetails.cs
@@ -11,10 +11,13 @@ using System.Diagnostics;
 
 namespace mrHelper.Client.Updates
 {
-   internal interface IWorkflowDetailsCache
+   internal struct WorkflowDetails
    {
-      List<MergeRequest> GetProjectMergeRequests(int projectId);
-      DateTime GetLatestCommitTimestamp(int mergeRequestId);
+      // maps unique project id to list of merge requests
+      public Dictionary<int, List<MergeRequest>> MergeRequests;
+
+      // maps unique Merge Request Id (not IId) to a timestamp of its latest commit
+      public Dictionary<int, DateTime> Commits;
    }
 }
 

--- a/src/Client/src/Updates/WorkflowDetailsCache.cs
+++ b/src/Client/src/Updates/WorkflowDetailsCache.cs
@@ -130,6 +130,12 @@ namespace mrHelper.Client.Updates
          DateTime previouslyCachedTimestamp = Details.GetLatestChangeTimestamp(mergeRequest.Id);
          Details.SetLatestChangeTimestamp(mergeRequest.Id, latestVersion.Created_At);
 
+         if (previouslyCachedTimestamp > latestVersion.Created_At)
+         {
+            Debug.Assert(false);
+            Trace.TraceWarning("[WorkflowDetailsCache] Latest version is older than a previous one");
+         }
+
          Trace.TraceInformation(String.Format(
             "[WorkflowDetailsCache] Latest version of merge request with Id {0} has timestamp {1} (was {2} before update)",
                mergeRequest.Id,

--- a/src/Client/src/Updates/WorkflowDetailsCache.cs
+++ b/src/Client/src/Updates/WorkflowDetailsCache.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using GitLabSharp.Entities;
+using mrHelper.Client.Tools;
+using mrHelper.Client.Updates;
+using mrHelper.Client.Workflow;
+using System.ComponentModel;
+using System.Diagnostics;
+
+namespace mrHelper.Client.Updates
+{
+   internal class WorkflowDetailsCache
+   {
+      internal WorkflowDetailsCache(UpdateOperator updateOperator, Workflow workflow)
+      {
+         UpdateOperator = updateOperator;
+         Workflow = workflow;
+      }
+
+      internal async void UpdateAsync()
+      {
+         await cacheMergeRequestsAsync(Workflow.State.HostName, Workflow.State.Project);
+
+         foreach (MergeRequest mergeRequest in CachedMergeRequests[Workflow.State.Project.Id])
+         {
+            await cacheCommitsAsync(Workflow.state.HostName, mergeRequest);
+         }
+      }
+
+      internal WorkflowDetails Details { get; private set; }
+
+      /// <summary>
+      /// Load merge requests from GitLab and cache them
+      /// </summary>
+      async private Task cacheMergeRequestsAsync(string hostname, Project project)
+      {
+         _cachedProjectNames[project.Id] = project.Path_With_Namespace;
+
+         Debug.WriteLine(String.Format("[WorkflowDetailsCache] Checking merge requests for project {0} (id {1})",
+            _cachedProjectNames[project.Id], project.Id));
+
+         List<MergeRequest> mergeRequests;
+         try
+         {
+            mergeRequests = await UpdateOperator.GetMergeRequestsAsync(hostname, _cachedProjectNames[project.Id]);
+         }
+         catch (OperatorException ex)
+         {
+            ExceptionHandlers.Handle(ex, String.Format("Cannot load merge requests for project Id {0}",
+               project.Id));
+            return;
+         }
+
+         if (_cachedMergeRequests.ContainsKey(project.Id))
+         {
+            List<MergeRequest> previouslyCachedMergeRequests = _cachedMergeRequests[project.Id];
+
+            Debug.WriteLine(String.Format(
+               "[WorkflowDetailsCache] {0} merge requests for this project were cached before",
+                  previouslyCachedMergeRequests.Count));
+
+            Debug.WriteLine("[WorkflowDetailsCache] Updating cached merge requests for this project");
+
+            _cachedMergeRequests[project.Id] = mergeRequests;
+         }
+         else
+         {
+            Debug.WriteLine(String.Format(
+               "[WorkflowDetailsCache] Merge requests for this project were not cached before"));
+            Debug.WriteLine("[WorkflowDetailsCache] Caching them now");
+
+            _cachedMergeRequests[project.Id] = mergeRequests;
+         }
+
+         Trace.TraceInformation(String.Format(
+            "[WorkflowDetailsCache] Cached {0} merge requests (unfiltered) for project {1} at {2}",
+               mergeRequests.Count, project.Path_With_Namespace, hostname));
+      }
+
+      /// <summary>
+      /// Load commits from GitLab and cache them
+      /// </summary>
+      async private Task cacheCommitsAsync(string hostname, MergeRequest mergeRequest)
+      {
+         Debug.WriteLine(String.Format(
+            "[WorkflowDetailsCache] Checking commits for merge request {0} from project {1}",
+               mergeRequest.IId, getMergeRequestProjectName(mergeRequest)));
+
+         MergeRequestDescriptor mrd = new MergeRequestDescriptor
+            {
+               HostName = hostname,
+               ProjectName = getMergeRequestProjectName(mergeRequest),
+               IId = mergeRequest.IId
+            };
+
+         Commit latestCommit;
+         try
+         {
+            latestCommit = await UpdateOperator.GetLatestCommitAsync(mrd);
+         }
+         catch (OperatorException ex)
+         {
+            ExceptionHandlers.Handle(ex, String.Format("Cannot load commits for mr Id {0}", mergeRequest.Id));
+            return;
+         }
+
+         if (_cachedCommits.ContainsKey(mergeRequest.Id))
+         {
+            Debug.WriteLine(String.Format(
+               "[WorkflowDetailsCache] Previously cached commit timestamp for this merge request is {0}",
+                  _cachedCommits[mergeRequest.Id]));
+
+            Debug.WriteLine(String.Format("[WorkflowDetailsCache] Updating cached commits for this merge request"));
+
+            _cachedCommits[mergeRequest.Id] = latestCommit.Created_At;
+         }
+         else
+         {
+            Debug.WriteLine(String.Format(
+               "[WorkflowDetailsCache] Commits for this merge request were not cached before"));
+            Debug.WriteLine(String.Format("[WorkflowDetailsCache] Caching them now"));
+
+            _cachedCommits[mergeRequest.Id] = latestCommit.Created_At;
+         }
+
+         Trace.TraceInformation(String.Format(
+            "[WorkflowDetailsCache] Latest commit for merge request with Id {0} has timestamp {1}. Cached.",
+               mergeRequest.Id, latestCommit.Created_At));
+      }
+
+      /// <summary>
+      /// Find a project name for a passed merge request
+      /// </summary>
+      private string getMergeRequestProjectName(MergeRequest mergeRequest)
+      {
+         if (_cachedProjectNames.ContainsKey(mergeRequest.Project_Id))
+         {
+            return _cachedProjectNames[mergeRequest.Project_Id];
+         }
+
+         return String.Empty;
+      }
+
+      // maps unique project id to project's Path with Namespace property
+      private readonly Dictionary<int, string> _cachedProjectNames = new Dictionary<int, string>();
+
+      private readonly UpdateOperator UpdateOperator { get; }
+      private readonly Workflow Workflow { get; }
+   }
+}
+

--- a/src/Client/src/Updates/WorkflowDetailsCacheItf.cs
+++ b/src/Client/src/Updates/WorkflowDetailsCacheItf.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using GitLabSharp.Entities;
+using mrHelper.Client.Tools;
+using mrHelper.Client.Updates;
+using mrHelper.Client.Workflow;
+using System.ComponentModel;
+using System.Diagnostics;
+
+namespace mrHelper.Client.Updates
+{
+   internal interface IWorkflowDetailsCache
+   {
+      List<MergeRequest> GetProjectMergeRequests(int projectId);
+      DateTime GetLatestCommitTimestamp(int mergeRequestId);
+   }
+}
+

--- a/src/Client/src/Updates/WorkflowDetailsChecker.cs
+++ b/src/Client/src/Updates/WorkflowDetailsChecker.cs
@@ -81,10 +81,10 @@ namespace mrHelper.Client.Updates
 
          foreach (MergeRequest mergeRequest in diff.Common)
          {
-            DateTime previouslyCachedCommitTimestamp = oldDetails.GetLatestCommitTimestamp(mergeRequest.Id);
-            DateTime newCachedCommitTimestamp = newDetails.GetLatestCommitTimestamp(mergeRequest.Id);
+            DateTime previouslyCachedChangeTimestamp = oldDetails.GetLatestChangeTimestamp(mergeRequest.Id);
+            DateTime newCachedChangeTimestamp = newDetails.GetLatestChangeTimestamp(mergeRequest.Id);
 
-            if (newCachedCommitTimestamp > previouslyCachedCommitTimestamp)
+            if (newCachedChangeTimestamp > previouslyCachedChangeTimestamp)
             {
                updates.UpdatedMergeRequests.Add(mergeRequest);
             }

--- a/src/Client/src/Updates/WorkflowDetailsChecker.cs
+++ b/src/Client/src/Updates/WorkflowDetailsChecker.cs
@@ -33,17 +33,17 @@ namespace mrHelper.Client.Updates
       /// <summary>
       /// Process a timer event
       /// </summary>
-      internal MergeRequestUpdates CheckForUpdates(List<Project> enabledProjects,
+      internal MergeRequestUpdates CheckForUpdates(string hostname, List<Project> enabledProjects,
          IWorkflowDetails oldDetails, IWorkflowDetails newDetails)
       {
-         TwoListDifference<MergeRequest> diff = getMergeRequestDiff(enabledProjects, oldDetails, newDetails);
+         TwoListDifference<MergeRequest> diff = getMergeRequestDiff(hostname, enabledProjects, oldDetails, newDetails);
          return getMergeRequestUpdates(diff, oldDetails, newDetails);
       }
 
       /// <summary>
       /// Calculate difference between two WorkflowDetails objects
       /// </summary>
-      private TwoListDifference<MergeRequest> getMergeRequestDiff(
+      private TwoListDifference<MergeRequest> getMergeRequestDiff(string hostname,
          List<Project> enabledProjects, IWorkflowDetails oldDetails, IWorkflowDetails newDetails)
       {
          TwoListDifference<MergeRequest> diff = new TwoListDifference<MergeRequest>
@@ -55,8 +55,9 @@ namespace mrHelper.Client.Updates
 
          foreach (var project in enabledProjects)
          {
-            List<MergeRequest> previouslyCachedMergeRequests = oldDetails.GetMergeRequests(project.Id);
-            List<MergeRequest> newCachedMergeRequests = newDetails.GetMergeRequests(project.Id);
+            ProjectKey key = new ProjectKey{ HostName = hostname, ProjectId = project.Id };
+            List<MergeRequest> previouslyCachedMergeRequests = oldDetails.GetMergeRequests(key);
+            List<MergeRequest> newCachedMergeRequests = newDetails.GetMergeRequests(key);
 
             diff.FirstOnly.AddRange(previouslyCachedMergeRequests.Except(newCachedMergeRequests).ToList());
             diff.SecondOnly.AddRange(newCachedMergeRequests.Except(previouslyCachedMergeRequests).ToList());

--- a/src/Client/src/Updates/WorkflowDetailsChecker.cs
+++ b/src/Client/src/Updates/WorkflowDetailsChecker.cs
@@ -34,7 +34,7 @@ namespace mrHelper.Client.Updates
       /// Process a timer event
       /// </summary>
       internal MergeRequestUpdates CheckForUpdates(List<Project> enabledProjects,
-         WorkflowDetails oldDetails, WorkflowDetails newDetails)
+         IWorkflowDetails oldDetails, IWorkflowDetails newDetails)
       {
          TwoListDifference<MergeRequest> diff = getMergeRequestDiff(enabledProjects, oldDetails, newDetails);
          return getMergeRequestUpdates(diff, oldDetails, newDetails);
@@ -44,7 +44,7 @@ namespace mrHelper.Client.Updates
       /// Calculate difference between two WorkflowDetails objects
       /// </summary>
       private TwoListDifference<MergeRequest> getMergeRequestDiff(
-         List<Project> enabledProjects, WorkflowDetails oldDetails, WorkflowDetails newDetails)
+         List<Project> enabledProjects, IWorkflowDetails oldDetails, IWorkflowDetails newDetails)
       {
          TwoListDifference<MergeRequest> diff = new TwoListDifference<MergeRequest>
          {
@@ -70,7 +70,7 @@ namespace mrHelper.Client.Updates
       /// Convert a difference between two states into a list of merge request updates splitted in new/updated/closed
       /// </summary>
       private MergeRequestUpdates getMergeRequestUpdates(
-         TwoListDifference<MergeRequest> diff, WorkflowDetails oldDetails, WorkflowDetails newDetails)
+         TwoListDifference<MergeRequest> diff, IWorkflowDetails oldDetails, IWorkflowDetails newDetails)
       {
          MergeRequestUpdates updates = new MergeRequestUpdates
          {

--- a/src/Client/src/Updates/WorkflowDetailsItf.cs
+++ b/src/Client/src/Updates/WorkflowDetailsItf.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using GitLabSharp.Entities;
+
+namespace mrHelper.Client.Updates
+{
+   internal interface IWorkflowDetails
+   {
+      /// <summary>
+      /// Create a copy of object
+      /// </summary>
+      IWorkflowDetails Clone();
+
+      /// <summary>
+      /// Return project name (Path_With_Namespace) by unique project Id
+      /// </summary>
+      string GetProjectName(int projectId);
+
+      /// <summary>
+      /// Return a list of merge requests by unique project id
+      /// </summary>
+      List<MergeRequest> GetMergeRequests(int projectId);
+
+      /// <summary>
+      /// Return a timestamp of the most recent version of a specified merge request
+      /// </summary>
+      DateTime GetLatestChangeTimestamp(int mergeRequestId);
+
+      /// <summary>
+      /// Return project Id by merge request Id
+      /// </summary>
+      int GetProjectId(int mergeRequestId);
+   }
+}
+

--- a/src/Client/src/Updates/WorkflowDetailsItf.cs
+++ b/src/Client/src/Updates/WorkflowDetailsItf.cs
@@ -4,6 +4,12 @@ using GitLabSharp.Entities;
 
 namespace mrHelper.Client.Updates
 {
+   internal struct ProjectKey
+   {
+      public string HostName;
+      public int ProjectId;
+   }
+
    internal interface IWorkflowDetails
    {
       /// <summary>
@@ -14,12 +20,12 @@ namespace mrHelper.Client.Updates
       /// <summary>
       /// Return project name (Path_With_Namespace) by unique project Id
       /// </summary>
-      string GetProjectName(int projectId);
+      string GetProjectName(ProjectKey key);
 
       /// <summary>
       /// Return a list of merge requests by unique project id
       /// </summary>
-      List<MergeRequest> GetMergeRequests(int projectId);
+      List<MergeRequest> GetMergeRequests(ProjectKey key);
 
       /// <summary>
       /// Return a timestamp of the most recent version of a specified merge request
@@ -29,7 +35,7 @@ namespace mrHelper.Client.Updates
       /// <summary>
       /// Return project Id by merge request Id
       /// </summary>
-      int GetProjectId(int mergeRequestId);
+      ProjectKey GetProjectKey(int mergeRequestId);
    }
 }
 

--- a/src/Client/src/Workflow/Workflow.cs
+++ b/src/Client/src/Workflow/Workflow.cs
@@ -81,9 +81,18 @@ namespace mrHelper.Client.Workflow
          Operator?.Dispose();
       }
 
-      public List<Project> GetEnabledProjects()
+      /// <summary>
+      /// Return projects at the current Host that are allowed to be checked for updates
+      /// </summary>
+      public List<Project> GetProjectsToUpdate()
       {
-         return getEnabledProjects();
+         List<Project> enabledProjects = getEnabledProjects();
+         if (enabledProject.Count != 0)
+         {
+            return enabledProjects;
+         }
+
+         return State.Project != default(Project) ? new List<Project>{ State.Project } : new List<Project>();
       }
 
       public event Action<string> PreSwitchHost;

--- a/src/Client/src/Workflow/Workflow.cs
+++ b/src/Client/src/Workflow/Workflow.cs
@@ -89,7 +89,10 @@ namespace mrHelper.Client.Workflow
 
       async public Task CancelAsync()
       {
-         await Operator?.CancelAsync();
+         if (Operator != null)
+         {
+            await Operator.CancelAsync();
+         }
       }
 
       public void Dispose()
@@ -110,7 +113,7 @@ namespace mrHelper.Client.Workflow
          }
 
          List<Project> enabledProjects = getEnabledProjects();
-         if (enabledProjects.Count != 0)
+         if ((enabledProjects?.Count ?? 0) != 0)
          {
             return enabledProjects;
          }
@@ -159,7 +162,7 @@ namespace mrHelper.Client.Workflow
          Operator = new WorkflowDataOperator(hostName, Tools.Tools.GetAccessToken(hostName, Settings));
 
          List<Project> enabledProjects = getEnabledProjects();
-         bool hasEnabledProjects = enabledProjects?.Count != 0;
+         bool hasEnabledProjects = (enabledProjects?.Count ?? 0) != 0;
 
          User currentUser;
          List<Project> projects;

--- a/src/Client/src/Workflow/Workflow.cs
+++ b/src/Client/src/Workflow/Workflow.cs
@@ -38,7 +38,6 @@ namespace mrHelper.Client.Workflow
             }
             else if (property.PropertyName == "LastUsedLabels")
             {
-               _cachedLabels = Tools.Tools.SplitLabels(Settings.LastUsedLabels);
                // emulate project change to reload merge request list
                try
                {
@@ -50,7 +49,6 @@ namespace mrHelper.Client.Workflow
                }
             }
          };
-         _cachedLabels = Tools.Tools.SplitLabels(Settings.LastUsedLabels);
       }
 
       async public Task Initialize(string hostname)
@@ -209,8 +207,7 @@ namespace mrHelper.Client.Workflow
          try
          {
             project = await Operator.GetProjectAsync(projectName);
-            mergeRequests = await Operator.GetMergeRequestsAsync(
-               project.Path_With_Namespace, Settings.CheckedLabelsFilter ? _cachedLabels : null);
+            mergeRequests = await Operator.GetMergeRequestsAsync(project.Path_With_Namespace);
          }
          catch (OperatorException ex)
          {
@@ -344,6 +341,8 @@ namespace mrHelper.Client.Workflow
 
       private int? selectMergeRequestFromList(List<MergeRequest> mergeRequests)
       {
+         mergeRequests = Tools.Tools.FilterMergeRequests(mergeRequests, Settings);
+
          HostAndProjectId key = new HostAndProjectId { Host = State.HostName, ProjectId = State.Project.Id };
          // if we remember MR selected for the given host/project before...
          if (_lastMergeRequestsByProjects.ContainsKey(key)
@@ -363,8 +362,6 @@ namespace mrHelper.Client.Workflow
 
       private UserDefinedSettings Settings { get; }
       private WorkflowDataOperator Operator { get; set; }
-
-      private List<string> _cachedLabels = null;
 
       private readonly Dictionary<string, string> _lastProjectsByHosts = new Dictionary<string, string>();
       private struct HostAndProjectId

--- a/src/Client/src/Workflow/WorkflowDataOperator.cs
+++ b/src/Client/src/Workflow/WorkflowDataOperator.cs
@@ -44,13 +44,6 @@ namespace mrHelper.Client.Workflow
 
       async internal Task<List<Project>> GetProjectsAsync(string hostName, bool publicOnly)
       {
-         List<Project> projects = Tools.Tools.LoadProjectsFromFile(hostName);
-         if (projects != null && projects.Count != 0)
-         {
-            await Client.CancelAsync();
-            return projects;
-         }
-
          try
          {
             return (List<Project>)(await Client.RunAsync(async (gl) =>

--- a/src/Client/src/Workflow/WorkflowDataOperator.cs
+++ b/src/Client/src/Workflow/WorkflowDataOperator.cs
@@ -77,7 +77,7 @@ namespace mrHelper.Client.Workflow
          }
       }
 
-      async internal Task<List<MergeRequest>> GetMergeRequestsAsync(string projectName, List<string> labels)
+      async internal Task<List<MergeRequest>> GetMergeRequestsAsync(string projectName)
       {
          List<MergeRequest> mergeRequests = null;
          try
@@ -94,14 +94,6 @@ namespace mrHelper.Client.Workflow
                throw new OperatorException(ex);
             }
             throw;
-         }
-
-         for (int iMergeRequest = mergeRequests.Count - 1; iMergeRequest >= 0; --iMergeRequest)
-         {
-            if (labels != null && labels.Intersect(mergeRequests[iMergeRequest].Labels).Count() == 0)
-            {
-               mergeRequests.RemoveAt(iMergeRequest);
-            }
          }
 
          return mergeRequests;


### PR DESCRIPTION
Introduced local cache of information about latest merge request versions.
This cache is updated when:
- Project/MR is selected by user
- Auto-update occurs on timer
This cache is used in the following cases:
- To figure out what changed on auto-update and make a decision about user notification
- To update internal timestamp of GitClientUpdater on ProjectWatcher notification
- To update internal timestamp of GitClientUpdater wher user launches diff tool
GitClientUpdater makes a decision if to run `git fetch` or not basing on its internal timestamp.
Underlying idea is very simple -- user can run diff tool only for those commits that are displayed in UI drop-downs. And these dropdowns are updated consistently with updates of local cache.
This means that if user launches a diff tool, we can be 100% sure that commits needed to run diff tool exist in local git repository.
However, when Discussions view is opened, we don't use local cache because discussions can be edited by other users who may see later commits. So for Discussions we check latest MR version at the GitLab.